### PR TITLE
Initial setup for prefundMessage

### DIFF
--- a/src/game-engine/application-states/ApplicationStatesPlayerA.js
+++ b/src/game-engine/application-states/ApplicationStatesPlayerA.js
@@ -34,7 +34,7 @@ class BasePlayerA {
         return {
             channel: this._channel,
             balances: this._balances,
-            stake: this.stake
+            stake: this.stake,
         }
     }
 }
@@ -43,6 +43,13 @@ class ReadyToSendPreFundSetup0 extends BasePlayerA {
     constructor({ channel, stake, balances, signedPreFundSetup0Message }) {
         super({channel, stake, balances});
         this.message = signedPreFundSetup0Message;
+    }
+
+    toJSON() {
+        return {
+            ...this.commonAttributes,
+            message: this.message,
+        }
     }
 }
 


### PR DESCRIPTION
This code change is just for the prefund message.

I think it makes sense to store messages in [firebase by channel Id ](https://github.com/magmo/rps-poc/compare/firebase-messages?expand=1#diff-1d5abf8c2ee621a0045e47d6c21217bbR35)

We can also later limit the listener to check only for messages for the current channel (right now it's collecting all messages)

Open questions:
- Where do we want to create instances of the `ChannelWallet` for player A and B? Do we need to store channel wallets locally or do we just care about the address?

Future changes:
- We'll need the opposing player who created the initial challenge to have a listener on when a challenge is accepted