### PR TITLE
Go back to simple enums

### DIFF
--- a/src/game-engine/application-states/ApplicationStatesPlayerA.js
+++ b/src/game-engine/application-states/ApplicationStatesPlayerA.js
@@ -146,7 +146,7 @@ class WaitForResting extends BasePlayerA {
     }
 }
 
-const types = {
+const types = Object.freeze({
     'ReadyToSendPreFundSetup0': 'ReadyToSendPreFundSetup0',
     'WaitForPreFundSetup1': 'WaitForPreFundSetup1',
     'ReadyToDeploy': 'ReadyToDeploy',
@@ -159,7 +159,7 @@ const types = {
     'WaitForAccept': 'WaitForAccept',
     'ReadyToSendReveal': 'ReadyToSendReveal',
     'WaitForResting': 'WaitForResting',
-};
+});
 
 export {
     types,

--- a/src/redux/actions/index.js
+++ b/src/redux/actions/index.js
@@ -1,11 +1,11 @@
-export const types = {
+export const types = Object.freeze({
   CHOOSE_OPPONENT: "CHOOSE_OPPONENT",
   CHOOSE_A_PLAY: "CHOOSE_A_PLAY",
   MESSAGE_RECEIVED: "MESSAGE_RECEIVED",
   EVENT_RECEIVED: "EVENT_RECEIVED",
   LOGIN_USER: "LOGIN_USER",
   LOGIN_SUCCESS: "LOGIN_SUCCESS",
-};
+});
 
 export const loginUser = () => ({
   type: types.LOGIN_USER,


### PR DESCRIPTION
This PR removes using the `Enum` object for the application state and action enums. This was prompted by the following issue:
```js
// previously when types were an Enum, this line would error
yield takeEvery(types.LOGIN_USER, loginSaga); 
// .. and needed to be rewritten as
yield takeEvery(types.LOGIN_USER.key, loginSaga);
```
I found this to be surprising behaviour - as a user of the `types` I'm thinking of them as stand ins for strings, so it was weird to be having to call `key`. You then have to be consistent about when you call `key` and when you don't, so that equality checks still work.

Although the style used in this PR involves repetition, it seems like a simpler approach with fewer surprises. We still use the `Enum` object when we actually need integers associated with the choices, like in the allowed plays.