### PR TITLE
Add pledges

### DIFF
--- a/src/game-engine/ChannelWallet.js
+++ b/src/game-engine/ChannelWallet.js
@@ -2,21 +2,21 @@ import { Message } from './Message';
 import Web3 from 'web3';
 
 export default class ChannelWallet {
-    constructor() {
-        let web3 = new Web3('');
-        this.account = web3.eth.accounts.create();
-    }
+  constructor() {
+    let web3 = new Web3('');
+    this.account = web3.eth.accounts.create();
+  }
 
-    get address() {
-        return this.account.address;
-    }
+  get address() {
+    return this.account.address;
+  }
 
-    get privateKey() {
-        return this.account.privateKey;
-    }
+  get privateKey() {
+    return this.account.privateKey;
+  }
 
-    sign(state) {
-        let signature = this.account.sign(state).signature;
-        return new Message({ state, signature });
-    }
+  sign(state) {
+    let signature = this.account.sign(state).signature;
+    return new Message({ state, signature });
+  }
 }

--- a/src/game-engine/Message.js
+++ b/src/game-engine/Message.js
@@ -1,16 +1,16 @@
-export class Message {
-    constructor({ state, signature, hexMessage }) {
-        if (hexMessage) {
-            hexMessage = hexMessage.substr(2)
-            state = '0x' + hexMessage.substr(0, hexMessage.length - 130);
-            signature = '0x' + hexMessage.substr(hexMessage.length - 130);
-        }
-
-        this.state = state;
-        this.signature = signature;
+export default class Message {
+  constructor({ state, signature, hexMessage }) {
+    if (hexMessage) {
+      hexMessage = hexMessage.substr(2)
+      state = '0x' + hexMessage.substr(0, hexMessage.length - 130);
+      signature = '0x' + hexMessage.substr(hexMessage.length - 130);
     }
 
-    toHex() {
-        return '0x' + this.state.substr(2) + this.signature.substr(2);
-    }
+    this.state = state;
+    this.signature = signature;
+  }
+
+  toHex() {
+    return '0x' + this.state.substr(2) + this.signature.substr(2);
+  }
 }

--- a/src/game-engine/application-states/ApplicationStatesPlayerB.js
+++ b/src/game-engine/application-states/ApplicationStatesPlayerB.js
@@ -1,159 +1,159 @@
 import Enum from 'enum';
 
 class BasePlayerB {
-    constructor({ channel, stake, balances }) {
-        this._channel = channel;
-        this._balances = balances;
-        this.stake = stake;
-    }
+  constructor({ channel, stake, balances }) {
+    this._channel = channel;
+    this._balances = balances;
+    this.stake = stake;
+  }
 
-    get myAddress() {
-        return this._channel.participants[1];
-    }
+  get myAddress() {
+    return this._channel.participants[1];
+  }
 
-    get opponentAddress() {
-        return this._channel.participants[0];
-    }
+  get opponentAddress() {
+    return this._channel.participants[0];
+  }
 
-    get channelId() {
-        return this._channel.channelId;
-    }
+  get channelId() {
+    return this._channel.channelId;
+  }
 
-    get myBalance() {
-        return this._balances[1];
-    }
+  get myBalance() {
+    return this._balances[1];
+  }
 
-    get opponentBalance() {
-        return this._balances[0];
-    }
+  get opponentBalance() {
+    return this._balances[0];
+  }
 
-    get type() {
-        return types[this.constructor.name];
-    }
+  get type() {
+    return types[this.constructor.name];
+  }
 
-    get commonAttributes() {
-        return {
-            channel: this._channel,
-            balances: this._balances,
-            stake: this.stake
-        }
+  get commonAttributes() {
+    return {
+      channel: this._channel,
+      balances: this._balances,
+      stake: this.stake
     }
+  }
 }
 
 class ReadyToSendPreFundSetup1 extends BasePlayerB {
-    constructor({ channel, stake, balances, signedPreFundSetup1Message }) {
-        super({ channel, stake, balances });
-        this.message = signedPreFundSetup1Message;
-    }
+  constructor({ channel, stake, balances, signedPreFundSetup1Message }) {
+    super({ channel, stake, balances });
+    this.message = signedPreFundSetup1Message;
+  }
 }
 
 class WaitForAToDeploy extends BasePlayerB {
-    constructor({ channel, stake, balances }) {
-        super({ channel, stake, balances });
-    }
+  constructor({ channel, stake, balances }) {
+    super({ channel, stake, balances });
+  }
 }
 
 class ReadyToDeposit extends BasePlayerB {
-    constructor({ channel, stake, balances, adjudicator, depositTransaction }) {
-        super({ channel, stake, balances });
-        this.adjudicator = adjudicator; // address of adjudicator
-        this.transaction = depositTransaction;
-    }
+  constructor({ channel, stake, balances, adjudicator, depositTransaction }) {
+    super({ channel, stake, balances });
+    this.adjudicator = adjudicator; // address of adjudicator
+    this.transaction = depositTransaction;
+  }
 }
 
 class WaitForBlockchainDeposit extends BasePlayerB {
-    constructor({ channel, stake, balances, adjudicator }) {
-        super({ channel, stake, balances });
-        this.adjudicator = adjudicator; // address of adjudicator
-    }
+  constructor({ channel, stake, balances, adjudicator }) {
+    super({ channel, stake, balances });
+    this.adjudicator = adjudicator; // address of adjudicator
+  }
 }
 
 class WaitForPostFundSetup0 extends BasePlayerB {
-    constructor({ channel, stake, balances, adjudicator }) {
-        super({ channel, stake, balances });
-        this.adjudicator = adjudicator; // address of adjudicator
-    }
+  constructor({ channel, stake, balances, adjudicator }) {
+    super({ channel, stake, balances });
+    this.adjudicator = adjudicator; // address of adjudicator
+  }
 }
 
 class ReadyToSendPostFundSetup1 extends BasePlayerB {
-    constructor({ channel, stake, balances, adjudicator, signedPostFundSetup1Message }) {
-        super({ channel, stake, balances });
-        this.adjudicator = adjudicator;
-        this.message = signedPostFundSetup1Message;
-    }
+  constructor({ channel, stake, balances, adjudicator, signedPostFundSetup1Message }) {
+    super({ channel, stake, balances });
+    this.adjudicator = adjudicator;
+    this.message = signedPostFundSetup1Message;
+  }
 }
 
 class WaitForPropose extends BasePlayerB {
-    constructor({ channel, stake, balances, adjudicator, signedPostFundSetup1Message }) {
-        super({ channel, stake, balances });
-        this.adjudicator = adjudicator;
-        this.message = signedPostFundSetup1Message; // in case resend necessary
-    }
+  constructor({ channel, stake, balances, adjudicator, signedPostFundSetup1Message }) {
+    super({ channel, stake, balances });
+    this.adjudicator = adjudicator;
+    this.message = signedPostFundSetup1Message; // in case resend necessary
+  }
 }
 
 class ReadyToChooseBPlay extends BasePlayerB {
-    constructor({ channel, stake, balances, adjudicator, opponentMessage }) {
-        super({ channel, stake, balances });
-        this.adjudicator = adjudicator;
-        this.opponentMessage = opponentMessage;
-    }
+  constructor({ channel, stake, balances, adjudicator, opponentMessage }) {
+    super({ channel, stake, balances });
+    this.adjudicator = adjudicator;
+    this.opponentMessage = opponentMessage;
+  }
 }
 
 class ReadyToSendAccept extends BasePlayerB {
-    constructor({ channel, stake, balances, adjudicator, bPlay, signedAcceptMessage }) {
-        super({ channel, stake, balances });
-        this.adjudicator = adjudicator;
-        this.bPlay = bPlay;
-        this.message = signedAcceptMessage;
-    }
+  constructor({ channel, stake, balances, adjudicator, bPlay, signedAcceptMessage }) {
+    super({ channel, stake, balances });
+    this.adjudicator = adjudicator;
+    this.bPlay = bPlay;
+    this.message = signedAcceptMessage;
+  }
 }
 
 class WaitForReveal extends BasePlayerB {
-    constructor({ channel, stake, balances, adjudicator, bPlay, signedAcceptMessage }) {
-        super({ channel, stake, balances });
-        this.adjudicator = adjudicator;
-        this.bPlay = bPlay;
-        this.message = signedAcceptMessage; // in case resend necessary
-    }
+  constructor({ channel, stake, balances, adjudicator, bPlay, signedAcceptMessage }) {
+    super({ channel, stake, balances });
+    this.adjudicator = adjudicator;
+    this.bPlay = bPlay;
+    this.message = signedAcceptMessage; // in case resend necessary
+  }
 }
 
 class ReadyToSendResting extends BasePlayerB {
-    constructor({ channel, stake, balances, adjudicator, aPlay, bPlay, result, salt, signedRestingMessage }) {
-        super({ channel, stake, balances });
-        this.aPlay = aPlay;
-        this.bPlay = bPlay;
-        this.result = result; // win/lose/draw
-        this.salt = salt;
-        this.adjudicator = adjudicator;
-        this.message = signedRestingMessage; // in case a resend is required
-    }
+  constructor({ channel, stake, balances, adjudicator, aPlay, bPlay, result, salt, signedRestingMessage }) {
+    super({ channel, stake, balances });
+    this.aPlay = aPlay;
+    this.bPlay = bPlay;
+    this.result = result; // win/lose/draw
+    this.salt = salt;
+    this.adjudicator = adjudicator;
+    this.message = signedRestingMessage; // in case a resend is required
+  }
 }
 
 const types = {
- 'ReadyToSendPreFundSetup1': 'ReadyToSendPreFundSetup1',
- 'WaitForAToDeploy': 'WaitForAToDeploy',
- 'ReadyToDeposit': 'ReadyToDeposit',
- 'WaitForBlockchainDeposit': 'WaitForBlockchainDeposit',
- 'WaitForPostFundSetup0': 'WaitForPostFundSetup0',
- 'ReadyToSendPostFundSetup1': 'ReadyToSendPostFundSetup1',
- 'WaitForPropose': 'WaitForPropose',
- 'ReadyToChooseBPlay': 'ReadyToChooseBPlay',
- 'ReadyToSendAccept': 'ReadyToSendAccept',
- 'WaitForReveal': 'WaitForReveal',
- 'ReadyToSendResting': 'ReadyToSendResting'
+  'ReadyToSendPreFundSetup1': 'ReadyToSendPreFundSetup1',
+  'WaitForAToDeploy': 'WaitForAToDeploy',
+  'ReadyToDeposit': 'ReadyToDeposit',
+  'WaitForBlockchainDeposit': 'WaitForBlockchainDeposit',
+  'WaitForPostFundSetup0': 'WaitForPostFundSetup0',
+  'ReadyToSendPostFundSetup1': 'ReadyToSendPostFundSetup1',
+  'WaitForPropose': 'WaitForPropose',
+  'ReadyToChooseBPlay': 'ReadyToChooseBPlay',
+  'ReadyToSendAccept': 'ReadyToSendAccept',
+  'WaitForReveal': 'WaitForReveal',
+  'ReadyToSendResting': 'ReadyToSendResting'
 };
 
 export {
-    types,
-    ReadyToSendPreFundSetup1,
-    WaitForAToDeploy,
-    ReadyToDeposit,
-    WaitForBlockchainDeposit,
-    WaitForPostFundSetup0,
-    ReadyToSendPostFundSetup1,
-    WaitForPropose,
-    ReadyToChooseBPlay,
-    ReadyToSendAccept,
-    WaitForReveal,
-    ReadyToSendResting,
+  types,
+  ReadyToSendPreFundSetup1,
+  WaitForAToDeploy,
+  ReadyToDeposit,
+  WaitForBlockchainDeposit,
+  WaitForPostFundSetup0,
+  ReadyToSendPostFundSetup1,
+  WaitForPropose,
+  ReadyToChooseBPlay,
+  ReadyToSendAccept,
+  WaitForReveal,
+  ReadyToSendResting,
 }

--- a/src/game-engine/application-states/__tests__/ApplicationStatesPlayerA.test.js
+++ b/src/game-engine/application-states/__tests__/ApplicationStatesPlayerA.test.js
@@ -18,246 +18,246 @@ const bPlay = "scissors";
 const salt = "abc123";
 
 const itHasSharedFunctionality = (appState) => {
-    it("returns myAddress", () => {
-        expect(appState.myAddress).toEqual(participantA);
-    });
+  it("returns myAddress", () => {
+    expect(appState.myAddress).toEqual(participantA);
+  });
 
-    it("returns opponentAddress", () => {
-        expect(appState.opponentAddress).toEqual(participantB);
-    });
+  it("returns opponentAddress", () => {
+    expect(appState.opponentAddress).toEqual(participantB);
+  });
 
-    it("returns channelId", () => {
-        expect(appState.channelId).toEqual(channel.channelId);
-    });
+  it("returns channelId", () => {
+    expect(appState.channelId).toEqual(channel.channelId);
+  });
 
-    it("returns myBalance", () => {
-        expect(appState.myBalance).toEqual(aBal);
-    });
+  it("returns myBalance", () => {
+    expect(appState.myBalance).toEqual(aBal);
+  });
 
-    it("returns opponentBalance", () => {
-        expect(appState.opponentBalance).toEqual(bBal);
-    });
+  it("returns opponentBalance", () => {
+    expect(appState.opponentBalance).toEqual(bBal);
+  });
 };
 
 describe("ReadyToSendPreFundSetup0", () => {
-    let signedPreFundSetup0Message = "blahblah";
-    let appState = new AppStates.ReadyToSendPreFundSetup0({ ...coreProps, signedPreFundSetup0Message });
+  let signedPreFundSetup0Message = "blahblah";
+  let appState = new AppStates.ReadyToSendPreFundSetup0({ ...coreProps, signedPreFundSetup0Message });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("has a message", () => {
-        expect(appState.message).toEqual(signedPreFundSetup0Message);
-    });
+  it("has a message", () => {
+    expect(appState.message).toEqual(signedPreFundSetup0Message);
+  });
 
-    it("has the right type", () => {
-        expect(appState.type).toEqual(AppStates.types.ReadyToSendPreFundSetup0);
-    });
+  it("has the right type", () => {
+    expect(appState.type).toEqual(AppStates.types.ReadyToSendPreFundSetup0);
+  });
 });
 
 describe("WaitForPreFundSetup1", () => {
-    let signedPreFundSetup0Message = "blahblah";
-    let appState = new AppStates.WaitForPreFundSetup1({ ...coreProps, signedPreFundSetup0Message });
+  let signedPreFundSetup0Message = "blahblah";
+  let appState = new AppStates.WaitForPreFundSetup1({ ...coreProps, signedPreFundSetup0Message });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("has a message", () => {
-        expect(appState.message).toEqual(signedPreFundSetup0Message);
-    });
+  it("has a message", () => {
+    expect(appState.message).toEqual(signedPreFundSetup0Message);
+  });
 });
 
 describe("ReadyToDeploy", () => {
-    let deploymentTransaction = { some: "properties to craft a transaction" };
-    let appState = new AppStates.ReadyToDeploy({ ...coreProps, deploymentTransaction });
+  let deploymentTransaction = { some: "properties to craft a transaction" };
+  let appState = new AppStates.ReadyToDeploy({ ...coreProps, deploymentTransaction });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("has a transaction", () => {
-        expect(appState.transaction).toEqual(deploymentTransaction);
-    });
+  it("has a transaction", () => {
+    expect(appState.transaction).toEqual(deploymentTransaction);
+  });
 });
 
 describe("WaitForBlockchainDeploy", () => {
-    let appState = new AppStates.WaitForBlockchainDeploy({ ...coreProps });
+  let appState = new AppStates.WaitForBlockchainDeploy({ ...coreProps });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 });
 
 describe("WaitForBToDeposit", () => {
-    let appState = new AppStates.WaitForBToDeposit({ ...coreProps, adjudicator });
+  let appState = new AppStates.WaitForBToDeposit({ ...coreProps, adjudicator });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("returns the adjudicator address", () => {
-        expect(appState.adjudicator).toEqual(adjudicator);
-    });
+  it("returns the adjudicator address", () => {
+    expect(appState.adjudicator).toEqual(adjudicator);
+  });
 });
 
 describe("ReadyToSendPostFundSetup0", () => {
-    let signedPostFundSetup0Message = "blahblah";
-    let appState = new AppStates.ReadyToSendPostFundSetup0({ ...coreProps, adjudicator, signedPostFundSetup0Message });
+  let signedPostFundSetup0Message = "blahblah";
+  let appState = new AppStates.ReadyToSendPostFundSetup0({ ...coreProps, adjudicator, signedPostFundSetup0Message });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("returns the adjudicator address", () => {
-        expect(appState.adjudicator).toEqual(adjudicator);
-    });
+  it("returns the adjudicator address", () => {
+    expect(appState.adjudicator).toEqual(adjudicator);
+  });
 
-    it("has a message", () => {
-        expect(appState.message).toEqual(signedPostFundSetup0Message);
-    });
+  it("has a message", () => {
+    expect(appState.message).toEqual(signedPostFundSetup0Message);
+  });
 });
 
 describe("WaitForPostFundSetup1", () => {
-    let signedPostFundSetup0Message = "blahblah";
-    let appState = new AppStates.WaitForPostFundSetup1({ ...coreProps, adjudicator, signedPostFundSetup0Message });
+  let signedPostFundSetup0Message = "blahblah";
+  let appState = new AppStates.WaitForPostFundSetup1({ ...coreProps, adjudicator, signedPostFundSetup0Message });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("returns the adjudicator address", () => {
-        expect(appState.adjudicator).toEqual(adjudicator);
-    });
+  it("returns the adjudicator address", () => {
+    expect(appState.adjudicator).toEqual(adjudicator);
+  });
 
-    it("has a message", () => {
-        expect(appState.message).toEqual(signedPostFundSetup0Message);
-    });
+  it("has a message", () => {
+    expect(appState.message).toEqual(signedPostFundSetup0Message);
+  });
 });
 
 describe("ReadyToChooseAPlay", () => {
-    let appState = new AppStates.ReadyToChooseAPlay({ ...coreProps, adjudicator });
+  let appState = new AppStates.ReadyToChooseAPlay({ ...coreProps, adjudicator });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("returns the adjudicator address", () => {
-        expect(appState.adjudicator).toEqual(adjudicator);
-    });
+  it("returns the adjudicator address", () => {
+    expect(appState.adjudicator).toEqual(adjudicator);
+  });
 });
 
 describe("ReadyToSendPropose", () => {
-    let signedProposeMessage = "some message";
-    let appState = new AppStates.ReadyToSendPropose({
-        ...coreProps,
-        adjudicator,
-        aPlay,
-        salt,
-        signedProposeMessage
-    });
+  let signedProposeMessage = "some message";
+  let appState = new AppStates.ReadyToSendPropose({
+    ...coreProps,
+    adjudicator,
+    aPlay,
+    salt,
+    signedProposeMessage
+  });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("returns the adjudicator address", () => {
-        expect(appState.adjudicator).toEqual(adjudicator);
-    });
+  it("returns the adjudicator address", () => {
+    expect(appState.adjudicator).toEqual(adjudicator);
+  });
 
-    it("returns aPlay", () => {
-        expect(appState.aPlay).toEqual(aPlay);
-    });
+  it("returns aPlay", () => {
+    expect(appState.aPlay).toEqual(aPlay);
+  });
 
-    it("returns the salt", () => {
-        expect(appState.salt).toEqual(salt);
-    });
+  it("returns the salt", () => {
+    expect(appState.salt).toEqual(salt);
+  });
 
-    it("returns the message", () => {
-        expect(appState.message).toEqual(signedProposeMessage);
-    });
+  it("returns the message", () => {
+    expect(appState.message).toEqual(signedProposeMessage);
+  });
 });
 
 describe("WaitForAccept", () => {
-    let signedProposeMessage = "some message";
-    let appState = new AppStates.WaitForAccept({
-        ...coreProps,
-        adjudicator,
-        aPlay,
-        salt,
-        signedProposeMessage
-    });
+  let signedProposeMessage = "some message";
+  let appState = new AppStates.WaitForAccept({
+    ...coreProps,
+    adjudicator,
+    aPlay,
+    salt,
+    signedProposeMessage
+  });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("returns the adjudicator address", () => {
-        expect(appState.adjudicator).toEqual(adjudicator);
-    });
+  it("returns the adjudicator address", () => {
+    expect(appState.adjudicator).toEqual(adjudicator);
+  });
 
-    it("returns aPlay", () => {
-        expect(appState.aPlay).toEqual(aPlay);
-    });
+  it("returns aPlay", () => {
+    expect(appState.aPlay).toEqual(aPlay);
+  });
 
-    it("returns the salt", () => {
-        expect(appState.salt).toEqual(salt);
-    });
+  it("returns the salt", () => {
+    expect(appState.salt).toEqual(salt);
+  });
 
-    it("returns the message", () => {
-        expect(appState.message).toEqual(signedProposeMessage);
-    });
+  it("returns the message", () => {
+    expect(appState.message).toEqual(signedProposeMessage);
+  });
 });
 
 describe("ReadyToSendReveal", () => {
-    let signedRevealMessage = "some message";
-    let result = "won";
-    let appState = new AppStates.ReadyToSendReveal({
-        ...coreProps,
-        adjudicator,
-        aPlay,
-        bPlay,
-        result,
-        salt,
-        signedRevealMessage
-    });
+  let signedRevealMessage = "some message";
+  let result = "won";
+  let appState = new AppStates.ReadyToSendReveal({
+    ...coreProps,
+    adjudicator,
+    aPlay,
+    bPlay,
+    result,
+    salt,
+    signedRevealMessage
+  });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("returns the adjudicator address", () => {
-        expect(appState.adjudicator).toEqual(adjudicator);
-    });
+  it("returns the adjudicator address", () => {
+    expect(appState.adjudicator).toEqual(adjudicator);
+  });
 
-    it("returns aPlay", () => {
-        expect(appState.aPlay).toEqual(aPlay);
-    });
+  it("returns aPlay", () => {
+    expect(appState.aPlay).toEqual(aPlay);
+  });
 
-    it("returns the salt", () => {
-        expect(appState.salt).toEqual(salt);
-    });
+  it("returns the salt", () => {
+    expect(appState.salt).toEqual(salt);
+  });
 
-    it("returns bPlay", () => {
-        expect(appState.bPlay).toEqual(bPlay);
-    });
+  it("returns bPlay", () => {
+    expect(appState.bPlay).toEqual(bPlay);
+  });
 
-    it("returns the message", () => {
-        expect(appState.message).toEqual(signedRevealMessage);
-    });
+  it("returns the message", () => {
+    expect(appState.message).toEqual(signedRevealMessage);
+  });
 });
 
 describe("WaitForResting", () => {
-    let signedRevealMessage = "some message";
-    let result = "won";
-    let appState = new AppStates.WaitForResting({
-        ...coreProps,
-        adjudicator,
-        aPlay,
-        bPlay,
-        result,
-        salt,
-        signedRevealMessage
-    });
+  let signedRevealMessage = "some message";
+  let result = "won";
+  let appState = new AppStates.WaitForResting({
+    ...coreProps,
+    adjudicator,
+    aPlay,
+    bPlay,
+    result,
+    salt,
+    signedRevealMessage
+  });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("returns the adjudicator address", () => {
-        expect(appState.adjudicator).toEqual(adjudicator);
-    });
+  it("returns the adjudicator address", () => {
+    expect(appState.adjudicator).toEqual(adjudicator);
+  });
 
-    it("returns aPlay", () => {
-        expect(appState.aPlay).toEqual(aPlay);
-    });
+  it("returns aPlay", () => {
+    expect(appState.aPlay).toEqual(aPlay);
+  });
 
-    it("returns the salt", () => {
-        expect(appState.salt).toEqual(salt);
-    });
+  it("returns the salt", () => {
+    expect(appState.salt).toEqual(salt);
+  });
 
-    it("returns bPlay", () => {
-        expect(appState.bPlay).toEqual(bPlay);
-    });
+  it("returns bPlay", () => {
+    expect(appState.bPlay).toEqual(bPlay);
+  });
 
-    it("returns the message", () => {
-        expect(appState.message).toEqual(signedRevealMessage);
-    });
+  it("returns the message", () => {
+    expect(appState.message).toEqual(signedRevealMessage);
+  });
 });

--- a/src/game-engine/application-states/__tests__/ApplicationStatesPlayerB.test.js
+++ b/src/game-engine/application-states/__tests__/ApplicationStatesPlayerB.test.js
@@ -19,214 +19,214 @@ const salt = "abc123";
 
 
 const itHasSharedFunctionality = (appState) => {
-    it("returns myAddress", () => {
-        expect(appState.myAddress).toEqual(participantB);
-    });
+  it("returns myAddress", () => {
+    expect(appState.myAddress).toEqual(participantB);
+  });
 
-    it("returns opponentAddress", () => {
-        expect(appState.opponentAddress).toEqual(participantA);
-    });
+  it("returns opponentAddress", () => {
+    expect(appState.opponentAddress).toEqual(participantA);
+  });
 
-    it("returns channelId", () => {
-        expect(appState.channelId).toEqual(channel.channelId);
-    });
+  it("returns channelId", () => {
+    expect(appState.channelId).toEqual(channel.channelId);
+  });
 
-    it("returns myBalance", () => {
-        expect(appState.myBalance).toEqual(bBal);
-    });
+  it("returns myBalance", () => {
+    expect(appState.myBalance).toEqual(bBal);
+  });
 
-    it("returns opponentBalance", () => {
-        expect(appState.opponentBalance).toEqual(aBal);
-    });
+  it("returns opponentBalance", () => {
+    expect(appState.opponentBalance).toEqual(aBal);
+  });
 };
 
 describe("ReadyToSendPreFundSetup0", () => {
-    let signedPreFundSetup1Message = "blahblah";
-    let appState = new AppStates.ReadyToSendPreFundSetup1({ ...coreProps, signedPreFundSetup1Message });
+  let signedPreFundSetup1Message = "blahblah";
+  let appState = new AppStates.ReadyToSendPreFundSetup1({ ...coreProps, signedPreFundSetup1Message });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("has a message", () => {
-        expect(appState.message).toEqual(signedPreFundSetup1Message);
-    });
+  it("has a message", () => {
+    expect(appState.message).toEqual(signedPreFundSetup1Message);
+  });
 });
 
 describe("WaitForAToDeploy", () => {
-    let appState = new AppStates.WaitForAToDeploy({ ...coreProps });
+  let appState = new AppStates.WaitForAToDeploy({ ...coreProps });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 });
 
 describe("ReadyToDeposit", () => {
-    let depositTransaction = { some: "transaction properties" };
-    let appState = new AppStates.ReadyToDeposit({ ...coreProps, adjudicator, depositTransaction });
+  let depositTransaction = { some: "transaction properties" };
+  let appState = new AppStates.ReadyToDeposit({ ...coreProps, adjudicator, depositTransaction });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("has a transaction", () => {
-        expect(appState.transaction).toEqual(depositTransaction);
-    });
+  it("has a transaction", () => {
+    expect(appState.transaction).toEqual(depositTransaction);
+  });
 
-    it("returns the address of the adjudicator", () => {
-        expect(appState.adjudicator).toEqual(adjudicator);
-    });
+  it("returns the address of the adjudicator", () => {
+    expect(appState.adjudicator).toEqual(adjudicator);
+  });
 });
 
 describe("WaitForBlockchainDeposit", () => {
-    let appState = new AppStates.WaitForBlockchainDeposit({ ...coreProps, adjudicator });
+  let appState = new AppStates.WaitForBlockchainDeposit({ ...coreProps, adjudicator });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("returns the address of the adjudicator", () => {
-        expect(appState.adjudicator).toEqual(adjudicator);
-    });
+  it("returns the address of the adjudicator", () => {
+    expect(appState.adjudicator).toEqual(adjudicator);
+  });
 });
 
 describe("WaitForPostFundSetup0", () => {
-    let appState = new AppStates.WaitForPostFundSetup0({ ...coreProps, adjudicator });
+  let appState = new AppStates.WaitForPostFundSetup0({ ...coreProps, adjudicator });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("returns the address of the adjudicator", () => {
-        expect(appState.adjudicator).toEqual(adjudicator);
-    });
+  it("returns the address of the adjudicator", () => {
+    expect(appState.adjudicator).toEqual(adjudicator);
+  });
 });
 
 describe("ReadyToSendPostFundSetup1", () => {
-    let signedPostFundSetup1Message = "some message";
-    let appState = new AppStates.ReadyToSendPostFundSetup1({
-        ...coreProps,
-        adjudicator,
-        signedPostFundSetup1Message,
-    });
+  let signedPostFundSetup1Message = "some message";
+  let appState = new AppStates.ReadyToSendPostFundSetup1({
+    ...coreProps,
+    adjudicator,
+    signedPostFundSetup1Message,
+  });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("returns the address of the adjudicator", () => {
-        expect(appState.adjudicator).toEqual(adjudicator);
-    });
+  it("returns the address of the adjudicator", () => {
+    expect(appState.adjudicator).toEqual(adjudicator);
+  });
 
-    it("has a message", () => {
-        expect(appState.message).toEqual(signedPostFundSetup1Message);
-    });
+  it("has a message", () => {
+    expect(appState.message).toEqual(signedPostFundSetup1Message);
+  });
 });
 
 describe("WaitForPropose", () => {
-    let signedPostFundSetup1Message = "some message";
-    let appState = new AppStates.WaitForPropose({
-        ...coreProps,
-        adjudicator,
-        signedPostFundSetup1Message,
-    });
+  let signedPostFundSetup1Message = "some message";
+  let appState = new AppStates.WaitForPropose({
+    ...coreProps,
+    adjudicator,
+    signedPostFundSetup1Message,
+  });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("returns the address of the adjudicator", () => {
-        expect(appState.adjudicator).toEqual(adjudicator);
-    });
+  it("returns the address of the adjudicator", () => {
+    expect(appState.adjudicator).toEqual(adjudicator);
+  });
 
-    it("has a message", () => {
-        expect(appState.message).toEqual(signedPostFundSetup1Message);
-    });
+  it("has a message", () => {
+    expect(appState.message).toEqual(signedPostFundSetup1Message);
+  });
 });
 
 describe("ReadyToChooseBPlay", () => {
-    let appState = new AppStates.ReadyToChooseBPlay({
-        ...coreProps,
-        adjudicator,
-    });
+  let appState = new AppStates.ReadyToChooseBPlay({
+    ...coreProps,
+    adjudicator,
+  });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("returns the address of the adjudicator", () => {
-        expect(appState.adjudicator).toEqual(adjudicator);
-    });
+  it("returns the address of the adjudicator", () => {
+    expect(appState.adjudicator).toEqual(adjudicator);
+  });
 });
 
 describe("ReadyToSendAccept", () => {
-    let signedAcceptMessage = "some message";
-    let appState = new AppStates.ReadyToSendAccept({
-        ...coreProps,
-        adjudicator,
-        bPlay,
-        signedAcceptMessage,
-    });
+  let signedAcceptMessage = "some message";
+  let appState = new AppStates.ReadyToSendAccept({
+    ...coreProps,
+    adjudicator,
+    bPlay,
+    signedAcceptMessage,
+  });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("returns the address of the adjudicator", () => {
-        expect(appState.adjudicator).toEqual(adjudicator);
-    });
+  it("returns the address of the adjudicator", () => {
+    expect(appState.adjudicator).toEqual(adjudicator);
+  });
 
-    it("returns b's play", () => {
-        expect(appState.bPlay).toEqual(bPlay);
-    });
+  it("returns b's play", () => {
+    expect(appState.bPlay).toEqual(bPlay);
+  });
 
-    it("has a message", () => {
-        expect(appState.message).toEqual(signedAcceptMessage);
-    });
+  it("has a message", () => {
+    expect(appState.message).toEqual(signedAcceptMessage);
+  });
 });
 
 describe("WaitForReveal", () => {
-    let signedAcceptMessage = "some message";
-    let appState = new AppStates.WaitForReveal({
-        ...coreProps,
-        adjudicator,
-        bPlay,
-        signedAcceptMessage,
-    });
+  let signedAcceptMessage = "some message";
+  let appState = new AppStates.WaitForReveal({
+    ...coreProps,
+    adjudicator,
+    bPlay,
+    signedAcceptMessage,
+  });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("returns the address of the adjudicator", () => {
-        expect(appState.adjudicator).toEqual(adjudicator);
-    });
+  it("returns the address of the adjudicator", () => {
+    expect(appState.adjudicator).toEqual(adjudicator);
+  });
 
-    it("returns b's play", () => {
-        expect(appState.bPlay).toEqual(bPlay);
-    });
+  it("returns b's play", () => {
+    expect(appState.bPlay).toEqual(bPlay);
+  });
 
-    it("has a message", () => {
-        expect(appState.message).toEqual(signedAcceptMessage);
-    });
+  it("has a message", () => {
+    expect(appState.message).toEqual(signedAcceptMessage);
+  });
 });
 
 describe("ReadyToSendResting", () => {
-    let signedRestingMessage = "some message";
-    let result = "lose";
-    let appState = new AppStates.ReadyToSendResting({
-        ...coreProps,
-        adjudicator,
-        bPlay,
-        aPlay,
-        salt,
-        result,
-        signedRestingMessage,
-    });
+  let signedRestingMessage = "some message";
+  let result = "lose";
+  let appState = new AppStates.ReadyToSendResting({
+    ...coreProps,
+    adjudicator,
+    bPlay,
+    aPlay,
+    salt,
+    result,
+    signedRestingMessage,
+  });
 
-    itHasSharedFunctionality(appState);
+  itHasSharedFunctionality(appState);
 
-    it("returns the address of the adjudicator", () => {
-        expect(appState.adjudicator).toEqual(adjudicator);
-    });
+  it("returns the address of the adjudicator", () => {
+    expect(appState.adjudicator).toEqual(adjudicator);
+  });
 
-    it("returns b's play", () => {
-        expect(appState.bPlay).toEqual(bPlay);
-    });
+  it("returns b's play", () => {
+    expect(appState.bPlay).toEqual(bPlay);
+  });
 
-    it("returns a's play", () => {
-        expect(appState.aPlay).toEqual(aPlay);
-    });
+  it("returns a's play", () => {
+    expect(appState.aPlay).toEqual(aPlay);
+  });
 
-    it("returns the salt", () => {
-        expect(appState.aPlay).toEqual(aPlay);
-    });
+  it("returns the salt", () => {
+    expect(appState.aPlay).toEqual(aPlay);
+  });
 
-    it("returns the result", () => {
-        expect(appState.result).toEqual(result);
-    });
+  it("returns the result", () => {
+    expect(appState.result).toEqual(result);
+  });
 
-    it("has a message", () => {
-        expect(appState.message).toEqual(signedRestingMessage);
-    });
+  it("has a message", () => {
+    expect(appState.message).toEqual(signedRestingMessage);
+  });
 });

--- a/src/game-engine/pledges/Accept.ts
+++ b/src/game-engine/pledges/Accept.ts
@@ -1,0 +1,31 @@
+import { State } from 'fmg-core';
+import { packAcceptAttributes, Play } from '.';
+
+export default class Accept extends State {
+  stake: number;
+  preCommit: string;
+  bPlay: Play;
+
+  constructor(
+    channel,
+    turnNum: number,
+    balances: number[],
+    stake: number,
+    preCommit: string,
+    bPlay: Play,
+  ) {
+    const stateType = State.StateTypes.GAME;
+    super({ channel, stateType, turnNum, resolution: balances });
+    this.stake = stake;
+    this.preCommit = preCommit;
+    this.bPlay = bPlay;
+  }
+
+  toHex() {
+    return super.toHex() + packAcceptAttributes(
+      this.stake,
+      this.preCommit,
+      this.bPlay,
+    );
+  }
+}

--- a/src/game-engine/pledges/Conclude.ts
+++ b/src/game-engine/pledges/Conclude.ts
@@ -1,0 +1,12 @@
+import { State } from 'fmg-core';
+
+export default class Conclude extends State {
+  constructor(channel, turnNum: number, balances: number[]) {
+    const stateType = State.StateTypes.CONCLUDE;
+    super({ channel, stateType, turnNum, resolution: balances });
+  }
+
+  toHex() {
+    return super.toHex();
+  }
+}

--- a/src/game-engine/pledges/PostFundSetup.ts
+++ b/src/game-engine/pledges/PostFundSetup.ts
@@ -1,0 +1,22 @@
+import { State } from 'fmg-core';
+import { packRestingAttributes } from '.';
+
+export default class PostFundSetup extends State {
+  stake: number;
+
+  constructor(
+    channel,
+    turnNum: number,
+    balances: number[],
+    stateCount: number,
+    stake: number,
+  ) {
+    const stateType = State.StateTypes.POSTFUNDSETUP;
+    super({ channel, stateType, turnNum, stateCount, resolution: balances });
+    this.stake = stake;
+  }
+
+  toHex() {
+    return super.toHex() + packRestingAttributes(this.stake);
+  }
+}

--- a/src/game-engine/pledges/PreFundSetup.ts
+++ b/src/game-engine/pledges/PreFundSetup.ts
@@ -1,0 +1,22 @@
+import { State } from 'fmg-core';
+import { packRestingAttributes } from '.';
+
+export default class PreFundSetup extends State {
+  stake: number;
+
+  constructor(
+    channel,
+    turnNum: number,
+    balances: number[],
+    stateCount: number,
+    stake: number,
+  ) {
+    const stateType = State.StateTypes.PREFUNDSETUP;
+    super({ channel, stateType, turnNum, stateCount, resolution: balances });
+    this.stake = stake;
+  }
+
+  toHex() {
+    return super.toHex() + packRestingAttributes(this.stake);
+  }
+}

--- a/src/game-engine/pledges/Propose.ts
+++ b/src/game-engine/pledges/Propose.ts
@@ -1,0 +1,36 @@
+import { State } from 'fmg-core';
+import { packProposeAttributes, hashCommitment, Play } from '.';
+
+export default class Resting extends State {
+  stake: number;
+  preCommit: string;
+
+  constructor(
+    channel,
+    turnNum: number,
+    balances: number[],
+    stake: number,
+    preCommit: string,
+  ) {
+    const stateType = State.StateTypes.GAME;
+    super({ channel, stateType, turnNum, resolution: balances });
+    this.stake = stake;
+    this.preCommit = preCommit;
+  }
+
+  static createWithPlayAndSalt (
+    channel,
+    turnNum: number,
+    balances: number[],
+    stake: number,
+    aPlay: Play,
+    salt: string,
+  ) {
+    const preCommit = hashCommitment(aPlay, salt);
+    return new Resting(channel, turnNum, balances, stake, preCommit);
+  }
+
+  toHex() {
+    return super.toHex() + packProposeAttributes(this.stake, this.preCommit);
+  }
+}

--- a/src/game-engine/pledges/Resting.ts
+++ b/src/game-engine/pledges/Resting.ts
@@ -1,0 +1,16 @@
+import { State } from 'fmg-core';
+import { packRestingAttributes } from '.';
+
+export default class Resting extends State {
+  stake: number;
+
+  constructor(channel, turnNum: number, balances: number[], stake: number) {
+    const stateType = State.StateTypes.GAME;
+    super({ channel, stateType, turnNum, resolution: balances });
+    this.stake = stake;
+  }
+
+  toHex() {
+    return super.toHex() + packRestingAttributes(this.stake);
+  }
+}

--- a/src/game-engine/pledges/Reveal.ts
+++ b/src/game-engine/pledges/Reveal.ts
@@ -1,0 +1,36 @@
+import { State } from 'fmg-core';
+import { packRevealAttributes, Play } from '.';
+
+export default class Reveal extends State {
+  stake: number;
+  preCommit: string;
+  aPlay: Play;
+  bPlay: Play;
+  salt: string;
+
+  constructor(
+    channel,
+    turnNum: number,
+    balances: number[],
+    stake: number,
+    bPlay: Play,
+    aPlay: Play,
+    salt: string,
+  ) {
+    const stateType = State.StateTypes.GAME;
+    super({ channel, stateType, turnNum, resolution: balances });
+    this.stake = stake;
+    this.bPlay = bPlay;
+    this.aPlay = aPlay;
+    this.salt = salt;
+  }
+
+  toHex() {
+    return super.toHex() + packRevealAttributes(
+      this.stake,
+      this.bPlay,
+      this.aPlay,
+      this.salt
+    );
+  }
+}

--- a/src/game-engine/pledges/decode.test.ts
+++ b/src/game-engine/pledges/decode.test.ts
@@ -1,0 +1,46 @@
+import { Channel } from 'fmg-core';
+
+import { hashCommitment, Play } from '.';
+import decode from './decode';
+import PreFundSetup from './PreFundSetup';
+import PostFundSetup from './PostFundSetup';
+import Propose from './Propose';
+import Accept from './Accept';
+import Reveal from './Reveal';
+import Resting from './Resting';
+import Conclude from './Conclude';
+
+const gameLibrary = '0x0000000000000000000000000000000000000000000000000000000000000111';
+const channelNonce = 15;
+const participantA = '0x000000000000000000000000000000000000000000000000000000000000000a';
+const participantB = '0x000000000000000000000000000000000000000000000000000000000000000b';
+const participants = [participantA, participantB];
+const channel = new Channel(gameLibrary, channelNonce, participants);
+const stateCount = 0;
+const turnNum = 5;
+const stake = 1;
+const aBal = 4;
+const bBal = 5;
+const balances = [aBal, bBal];
+const aPlay = Play.Rock;
+const bPlay = Play.Scissors;
+const salt = '0x0000000000000000000000000000000000000000000000000000000000abc123';
+const preCommit = hashCommitment(aPlay, salt);
+
+const testEncodeDecode = (pledge) => {
+  it(`${pledge.constructor.name} is the same after encoding and decoding`, () => {
+    const encoded = pledge.toHex();
+    const decoded = decode(encoded);
+    expect(decoded).toEqual(pledge);
+  });
+};
+
+describe('decode', () => {
+  testEncodeDecode(new PreFundSetup(channel, turnNum, balances, stateCount, stake));
+  testEncodeDecode(new PostFundSetup(channel, turnNum, balances, stateCount, stake));
+  testEncodeDecode(Propose.createWithPlayAndSalt(channel, turnNum, balances, stake, aPlay, salt));
+  testEncodeDecode(new Accept(channel, turnNum, balances, stake, preCommit, bPlay));
+  testEncodeDecode(new Reveal(channel, turnNum, balances, stake, bPlay, aPlay, salt));
+  testEncodeDecode(new Resting(channel, turnNum, balances, stake));
+  testEncodeDecode(new Conclude(channel, turnNum, balances));
+});

--- a/src/game-engine/pledges/decode.ts
+++ b/src/game-engine/pledges/decode.ts
@@ -1,0 +1,141 @@
+import { Channel, State } from 'fmg-core';
+
+import { Play, Position } from '.';
+import PreFundSetup from './PreFundSetup';
+import PostFundSetup from './PostFundSetup';
+import Propose from './Propose';
+import Accept from './Accept';
+import Reveal from './Reveal';
+import Resting from './Resting';
+import Conclude from './Conclude';
+
+const PREFIX_CHARS = 2; // the 0x takes up 2 characters
+const CHARS_PER_BYTE = 2;
+const N_PLAYERS = 2;
+const CHANNEL_BYTES = 32 + 32 + 32 + 32 * N_PLAYERS; // type, nonce, nPlayers, [players]
+const STATE_BYTES = 32 + 32 + 32 + 32 * N_PLAYERS; // stateType, turnNum, stateCount, [balances]
+const GAME_ATTRIBUTE_OFFSET = CHANNEL_BYTES + STATE_BYTES;
+
+function extractInt(hexString: string, byteOffset: number = 0, numBytes: number = 32) {
+  return parseInt(extractBytes(hexString, byteOffset, numBytes));
+}
+
+function extractBytes(hexString: string, byteOffset: number = 0, numBytes: number = 32) {
+  const charOffset = PREFIX_CHARS + byteOffset * CHARS_PER_BYTE;
+  return '0x' + hexString.substr(charOffset, numBytes * CHARS_PER_BYTE);
+}
+
+function extractChannel(hexString: string) {
+  const channelType = extractBytes(hexString);
+  const channelNonce = extractInt(hexString, 32);
+  const nPlayers = extractInt(hexString, 64);
+  if (nPlayers != N_PLAYERS) {
+    throw new Error(
+      `Rock-paper-scissors requires exactly ${N_PLAYERS} players. ${nPlayers} provided.`
+    );
+  }
+
+  const participantA = extractBytes(hexString, 3 * 32);
+  const participantB = extractBytes(hexString, 4 * 32);
+
+  return new Channel(channelType, channelNonce, [participantA, participantB]);
+}
+
+function extractStateType(hexString: string) {
+  return extractInt(hexString, CHANNEL_BYTES);
+}
+
+function extractTurnNum(hexString: string) {
+  return extractInt(hexString, CHANNEL_BYTES + 32);
+}
+
+function extractStateCount(hexString: string) {
+  return extractInt(hexString, CHANNEL_BYTES + 64);
+}
+
+function extractBalances(hexString: string) {
+  const aBal = extractInt(hexString, CHANNEL_BYTES + 3 * 32);
+  const bBal = extractInt(hexString, CHANNEL_BYTES + 4 * 32);
+  return [aBal, bBal];
+}
+
+// RockPaperScissors State Fields
+// (relative to gamestate offset)
+// ==============================
+// [  0 -  31] enum positionType
+// [ 32 -  63] uint256 stake
+// [ 64 -  95] bytes32 preCommit
+// [ 96 - 127] enum bPlay
+// [128 - 159] enum aPlay
+// [160 - 191] bytes32 salt
+// [192 - 223] uint256 roundNum
+
+function extractPosition(hexString: string) {
+  return extractInt(hexString, GAME_ATTRIBUTE_OFFSET) as Position;
+}
+
+function extractStake(hexString: string) {
+  return extractInt(hexString, GAME_ATTRIBUTE_OFFSET + 32);
+}
+
+function extractPreCommit(hexString: string) {
+  return extractBytes(hexString, GAME_ATTRIBUTE_OFFSET + 64);
+}
+
+function extractBPlay(hexString: string) {
+  return extractInt(hexString, GAME_ATTRIBUTE_OFFSET + 3 * 32) as Play;
+}
+
+function extractAPlay(hexString: string) {
+  return extractInt(hexString, GAME_ATTRIBUTE_OFFSET + 4 * 32) as Play;
+}
+
+function extractSalt(hexString: string) {
+  return extractBytes(hexString, GAME_ATTRIBUTE_OFFSET + 5 * 32);
+}
+
+function decodeGameState(channel, turnNum: number, balances: number[], hexString: string) {
+  const position = extractPosition(hexString);
+  const stake = extractStake(hexString);
+
+  switch(position) {
+    case Position.Resting:
+      return new Resting(channel, turnNum, balances, stake);
+    case Position.Propose:
+      const preCommitPro = extractPreCommit(hexString);
+      return new Propose(channel, turnNum, balances, stake, preCommitPro);
+    case Position.Accept:
+      const preCommitAcc = extractPreCommit(hexString);
+      const bPlayAcc = extractBPlay(hexString);
+      return new Accept(channel, turnNum, balances, stake, preCommitAcc, bPlayAcc);
+    case Position.Reveal:
+      const bPlayRev = extractBPlay(hexString);
+      const aPlay = extractAPlay(hexString);
+      const salt = extractSalt(hexString);
+      return new Reveal(channel, turnNum, balances, stake, bPlayRev, aPlay, salt);
+  }
+}
+
+export default function decode(hexString) {
+  const channel = extractChannel(hexString);
+  const turnNum = extractTurnNum(hexString);
+  const stateType = extractStateType(hexString);
+  const balances = extractBalances(hexString);
+
+  switch(stateType) {
+    case State.StateTypes.CONCLUDE:
+      return new Conclude(channel, turnNum, balances);
+    case State.StateTypes.PREFUNDSETUP:
+      const stateCountPre = extractStateCount(hexString);
+      const stakePre = extractStake(hexString);
+      return new PreFundSetup(channel, turnNum, balances, stateCountPre, stakePre);
+    case State.StateTypes.POSTFUNDSETUP:
+      let stateCountPost = extractStateCount(hexString);
+      let stakePost = extractStake(hexString);
+      return new PostFundSetup(channel, turnNum, balances, stateCountPost, stakePost);
+    case State.StateTypes.GAME:
+      return decodeGameState(channel, turnNum, balances, hexString);
+    default:
+      throw new Error('unreachable');
+  }
+}

--- a/src/game-engine/pledges/index.ts
+++ b/src/game-engine/pledges/index.ts
@@ -1,0 +1,68 @@
+import { toHex32, padBytes32 } from 'fmg-core';
+import { soliditySha3 } from 'web3-utils';
+
+export enum Position {
+  Resting,
+  Propose,
+  Accept,
+  Reveal,
+}
+
+export enum Play {
+  Rock,
+  Paper,
+  Scissors
+}
+
+export enum Result {
+  Tie,
+  AWon,
+  BWon,
+}
+
+export function packRestingAttributes(stake: number) {
+  return (
+    toHex32(Position.Resting).substr(2) + 
+    toHex32(stake).substr(2)
+  );
+}
+
+export function packProposeAttributes(stake: number, preCommit: string) {
+  return (
+    toHex32(Position.Propose).substr(2) + 
+    toHex32(stake).substr(2) +
+    padBytes32(preCommit).substr(2)
+  );
+}
+
+export function packAcceptAttributes(stake: number, preCommit: string, bPlay: Play) {
+  return (
+    toHex32(Position.Accept).substr(2) + 
+    toHex32(stake).substr(2) +
+    padBytes32(preCommit).substr(2) +
+    toHex32(bPlay).substr(2)
+  );
+}
+
+export function packRevealAttributes(
+  stake: number, 
+  bPlay: Play,
+  aPlay: Play,
+  salt: string,
+) {
+  return (
+    toHex32(Position.Reveal).substr(2) + 
+    toHex32(stake).substr(2) +
+    padBytes32('0x0').substr(2) + // don't need the preCommit
+    toHex32(bPlay).substr(2) +
+    toHex32(aPlay).substr(2) +
+    padBytes32(salt).substr(2)
+  );
+}
+
+export function hashCommitment(play: Play, salt: string) {
+  return soliditySha3(
+    { type: 'uint256', value: play },
+    { type: 'bytes32', value: padBytes32(salt) },
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "baseUrl": ".",
     "outDir": "build/dist",
     "module": "esnext",
-    "target": "es5",
+    "target": "es2015",
     "lib": ["es6", "dom"],
     "sourceMap": true,
     "allowJs": true,


### PR DESCRIPTION
This PR adds "pledges" as a first step to refactoring the game-rules. The word "pledge" is intended to replace the ambiguously used "state" for the data that is signed and sent between players to progress the game.

The pledge objects map directly to the types of messages that can be sent between players. The pledge objects are responsible for serializing this data into the format understood by the smart contract, and also for deserializing back into pledge objects for use by the application.