### PR TITLE
[aphrodite] convert a single component to aphrodite

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/react-router-dom": "^4.3.0",
     "@types/web3": "^1.0.2",
     "ajv": "^6.5.1",
+    "aphrodite": "^2.2.2",
     "babel-core": "6",
     "babel-runtime": "^6.23.0",
     "enum": "^2.5.0",

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import { StyleSheet, css } from 'aphrodite';
+
+import { BRAND_COLOR } from '../constants';
 
 interface IProps {
   children: any;
@@ -7,10 +10,30 @@ interface IProps {
 
 const Button: React.SFC<IProps> = ({ children, onClick }) => {
   return (
-    <button onClick={onClick} type="button" className="button">
+    <button onClick={onClick} type="button" className={css(styles.button)}>
       {children}
     </button>
   );
 };
 
 export default Button;
+
+const styles = StyleSheet.create({
+  button: {
+    borderRadius: 3,
+    padding: '3px 16px 4px',
+    backgroundColor: BRAND_COLOR,
+    borderColor: '#666',
+    borderStyle: 'solid',
+    borderWidth: 1,
+    color: '#fff',
+    transition: 'background-color 0.5s ease',
+    boxShadow: '0px 0px 1px',
+    textTransform: 'uppercase',
+  },
+
+  ':hover': {
+    textDecorationLine: 'none',
+    backgroundColor: '#aaa',
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -549,6 +549,14 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
+aphrodite@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/aphrodite/-/aphrodite-2.2.2.tgz#1292a6c67f5c35f8855f3f61475fe530d903bdd1"
+  dependencies:
+    asap "^2.0.3"
+    inline-style-prefixer "^4.0.0"
+    string-hash "^1.1.3"
+
 append-transform@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-1.0.0.tgz#046a52ae582a228bd72f58acfbe2967c678759ab"
@@ -658,7 +666,7 @@ arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-asap@~2.0.3:
+asap@^2.0.3, asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
@@ -1721,6 +1729,10 @@ boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
 
+bowser@^1.7.3:
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.9.4.tgz#890c58a2813a9d3243704334fa81b96a5c150c9a"
+
 boxen@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz#55c6c39a8ba58d9c61ad22cd877532deb665a20b"
@@ -2673,6 +2685,13 @@ crypto-random-string@^1.0.0:
 css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
+
+css-in-js-utils@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz#3b472b398787291b47cfe3e44fecfdd9e914ba99"
+  dependencies:
+    hyphenate-style-name "^1.0.2"
+    isobject "^3.0.1"
 
 css-loader@0.28.7:
   version "0.28.7"
@@ -5005,6 +5024,10 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
+hyphenate-style-name@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
+
 ice-cap@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/ice-cap/-/ice-cap-0.0.4.tgz#8a6d31ab4cac8d4b56de4fa946df3352561b6e18"
@@ -5108,6 +5131,13 @@ inherits@2.0.1:
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
+
+inline-style-prefixer@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-4.0.2.tgz#d390957d26f281255fe101da863158ac6eb60911"
+  dependencies:
+    bowser "^1.7.3"
+    css-in-js-utils "^2.0.0"
 
 inquirer@3.3.0, inquirer@^3.0.6:
   version "3.3.0"
@@ -9440,6 +9470,10 @@ stream-shift@^1.0.0:
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+
+string-hash@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This is what styling with Aphrodite looks like - any issues with converting the rest of the css into this format? 

I confirmed that the Button component looks the same (that the switch worked).

I like this format because:
a. It keeps the styles in the same file as the component (great for development efficiency).
b. Classnames (keys in the styles object) are in js, which makes it easy to debug (vs. string classnames which are not linted against)
c. There is typescript support for CSS, which is not setup yet in our repo but sounds like a dream and not too hard to get set up.
