### PR TITLE
Removed forEach as the query only returns 1 result

### DIFF
--- a/src/redux/sagas/wallet.ts
+++ b/src/redux/sagas/wallet.ts
@@ -44,8 +44,7 @@ function* fetchWallet(uid: string) {
   // It seems like rsf.database.read doesn't really work when the result is a collection
 
   const result = yield call([query, query.once], 'value');
-  let wallet;
-  result.forEach((data) => { wallet = walletTransformer(data); }); // result should have size 1
+  const wallet  = walletTransformer(result); // There should only be 1 wallet returned
 
   return new ChannelWallet(wallet.privateKey);
 }


### PR DESCRIPTION
`forEach` was causing an error which seemed to be related to the query only returning 1 result (as specified by `limitToFirst(1)`). Since we know we're only getting back one result we can just pass `result` directly into `walletTransformer`