### PR TITLE
Add player B states

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -83,33 +83,33 @@ export default class GameController extends PureComponent<Props> {
         return <WaitingStep message="Wait for resting" />;
       
       case playerB.ReadyToSendPreFundSetupB:
-        return <WaitingStep message="opponent to accept the outcome" />;
+        return <WaitingStep message="ready to send prefund setup" />;
 
       case playerB.WaitForAToDeploy:
-        return <WaitingStep message="opponent to accept the outcome" />;
+        return <WaitingStep message="waiting for adjudicator to be deployed" />;
 
       case playerB.ReadyToDeposit:
-        return <WaitingStep message="opponent to accept the outcome" />;
+        return <WaitingStep message="ready to deposit funds" />;
 
       case playerB.WaitForBlockchainDeposit:
-        return <WaitingStep message="opponent to accept the outcome" />;
+        return <WaitingStep message="waiting for deposit confirmation" />;
 
       case playerB.WaitForPostFundSetupA:
-        return <WaitingStep message="opponent to accept the outcome" />;
+        return <WaitingStep message="waiting for post fund setup" />;
 
       case playerB.ReadyToSendPostFundSetupB:
-        return <WaitingStep message="opponent to accept the outcome" />;
+        return <WaitingStep message="ready to send post fund setup" />;
 
       case playerB.ReadyToChooseBPlay:
         return <SelectPlayStep choosePlay={choosePlay} />;
 
       case playerB.ReadyToSendAccept:
         // your choice
-        return <WaitingStep message="opponent to accept the outcome" />;
+        return <WaitingStep message="ready to send accept" />;
 
       case playerB.WaitForReveal:
         // choice made
-        return <WaitingStep message="opponent to accept the outcome" />;
+        return <WaitingStep message="opponent to reveal their move" />;
 
       case playerB.ReadyToSendResting:
         // result

--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -3,7 +3,8 @@ import React, { PureComponent } from 'react';
 import OpponentSelectionStep from './OpponentSelectionStep';
 import WaitingStep from './WaitingStep';
 import SelectPlayStep from './SelectPlayStep';
-import * as playerAStates from '../game-engine/application-states/PlayerA';
+import * as playerA from '../game-engine/application-states/PlayerA';
+import * as playerB from '../game-engine/application-states/PlayerB';
 import { GameState } from '../redux/reducers/game';
 import { Opponent } from '../redux/reducers/opponents';
 
@@ -11,7 +12,7 @@ import { Play } from '../game-engine/positions/index';
 
 interface Props {
   applicationState: GameState;
-  chooseAPlay: (aPlay: Play) => void; // TODO: what should this be?
+  choosePlay: (play: Play) => void; // TODO: what should this be?
   chooseOpponent: (opponentAddress: string, stake: number) => void;
   opponents: Opponent[];
   subscribeOpponents: () => void;
@@ -22,7 +23,7 @@ export default class GameController extends PureComponent<Props> {
   render() {
     const {
       applicationState,
-      chooseAPlay,
+      choosePlay,
       chooseOpponent,
       opponents,
       subscribeOpponents,
@@ -41,40 +42,70 @@ export default class GameController extends PureComponent<Props> {
     }
 
     switch (applicationState && applicationState.constructor) {
-      case playerAStates.ReadyToSendPreFundSetupA:
+      case playerA.ReadyToSendPreFundSetupA:
         return <WaitingStep message="ready to propose game" />;
 
-      case playerAStates.WaitForPreFundSetupB:
+      case playerA.WaitForPreFundSetupB:
         return <WaitingStep message="opponent to accept game" />;
 
-      case playerAStates.ReadyToDeploy:
+      case playerA.ReadyToDeploy:
         return <WaitingStep message="ready to deploy adjudicator" />;
 
-      case playerAStates.WaitForBlockchainDeploy:
+      case playerA.WaitForBlockchainDeploy:
         return <WaitingStep message="confirmation of adjudicator deployment" />;
 
-      case playerAStates.WaitForBToDeposit:
+      case playerA.WaitForBToDeposit:
         return <WaitingStep message="confirmation of opponent's deposit" />;
 
-      case playerAStates.ReadyToSendPostFundSetupA:
+      case playerA.ReadyToSendPostFundSetupA:
         return <WaitingStep message="ready to send deposit confirmation" />;
 
-      case playerAStates.WaitForPostFundSetupB:
+      case playerA.WaitForPostFundSetupB:
         return <WaitingStep message="opponent to confirm deposits" />;
 
-      case playerAStates.ReadyToChooseAPlay:
-        return <SelectPlayStep chooseAPlay={chooseAPlay} />;
+      case playerA.ReadyToChooseAPlay:
+        return <SelectPlayStep choosePlay={choosePlay} />;
 
-      case playerAStates.ReadyToSendPropose:
+      case playerA.ReadyToSendPropose:
         return <WaitingStep message="ready to send round proposal" />;
 
-      case playerAStates.WaitForAccept:
+      case playerA.WaitForAccept:
         return <WaitingStep message="opponent to choose their move" />;
 
-      case playerAStates.ReadyToSendReveal:
+      case playerA.ReadyToSendReveal:
         return <WaitingStep message="ready to send reveal" />;
 
-      case playerAStates.WaitForResting:
+      case playerA.WaitForResting:
+        return <WaitingStep message="Wait for resting" />;
+      
+      case playerB.ReadyToSendPreFundSetupB:
+        return <WaitingStep message="opponent to accept the outcome" />;
+
+      case playerB.WaitForAToDeploy:
+        return <WaitingStep message="opponent to accept the outcome" />;
+
+      case playerB.ReadyToDeposit:
+        return <WaitingStep message="opponent to accept the outcome" />;
+
+      case playerB.WaitForBlockchainDeposit:
+        return <WaitingStep message="opponent to accept the outcome" />;
+
+      case playerB.WaitForPostFundSetupA:
+        return <WaitingStep message="opponent to accept the outcome" />;
+
+      case playerB.ReadyToSendPostFundSetupB:
+        return <WaitingStep message="opponent to accept the outcome" />;
+
+      case playerB.ReadyToChooseBPlay:
+        return <SelectPlayStep choosePlay={choosePlay} />;
+
+      case playerB.ReadyToSendAccept:
+        return <WaitingStep message="opponent to accept the outcome" />;
+
+      case playerB.WaitForReveal:
+        return <WaitingStep message="opponent to accept the outcome" />;
+
+      case playerB.ReadyToSendResting:
         return <WaitingStep message="opponent to accept the outcome" />;
 
       default:

--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -67,15 +67,19 @@ export default class GameController extends PureComponent<Props> {
         return <SelectPlayStep choosePlay={choosePlay} />;
 
       case playerA.ReadyToSendPropose:
+        // choice made
         return <WaitingStep message="ready to send round proposal" />;
 
       case playerA.WaitForAccept:
+        // choice made
         return <WaitingStep message="opponent to choose their move" />;
 
       case playerA.ReadyToSendReveal:
+        // result
         return <WaitingStep message="ready to send reveal" />;
 
       case playerA.WaitForResting:
+        // result 
         return <WaitingStep message="Wait for resting" />;
       
       case playerB.ReadyToSendPreFundSetupB:
@@ -100,12 +104,15 @@ export default class GameController extends PureComponent<Props> {
         return <SelectPlayStep choosePlay={choosePlay} />;
 
       case playerB.ReadyToSendAccept:
+        // your choice
         return <WaitingStep message="opponent to accept the outcome" />;
 
       case playerB.WaitForReveal:
+        // choice made
         return <WaitingStep message="opponent to accept the outcome" />;
 
       case playerB.ReadyToSendResting:
+        // result
         return <WaitingStep message="opponent to accept the outcome" />;
 
       default:

--- a/src/components/SelectPlayStep.tsx
+++ b/src/components/SelectPlayStep.tsx
@@ -3,13 +3,13 @@ import React from 'react';
 import { Play } from '../game-engine/positions';
 
 interface Props {
-  chooseAPlay: (aPlay: Play) => void;
+  choosePlay: (play: Play) => void;
   afterOpponent?: any;
 }
 
 export default class SelectPlayStep extends React.PureComponent<Props> {
   render() {
-    const { chooseAPlay, afterOpponent } = this.props;
+    const { choosePlay, afterOpponent } = this.props;
 
     return (
       <div style={{ maxWidth: '90%', margin: 'auto' }}>
@@ -24,7 +24,7 @@ export default class SelectPlayStep extends React.PureComponent<Props> {
           {Object.keys(Play).filter(key => !isNaN(Number(key))).map(option => (
             <button
               type="button"
-              onClick={() => chooseAPlay(parseInt(option,10))}
+              onClick={() => choosePlay(Play[option])}
               style={{ display: 'inline-block', width: '33%' }}
               key={option}
             >

--- a/src/components/SelectPlayStep.tsx
+++ b/src/components/SelectPlayStep.tsx
@@ -8,8 +8,36 @@ interface Props {
 }
 
 export default class SelectPlayStep extends React.PureComponent<Props> {
+
+  renderChooseButton(choosePlay: (play: Play) => void, play: Play, description: string) {
+    return (
+      <button
+      type="button"
+      onClick={() => choosePlay(play)}
+      style={{ display: 'inline-block', width: '33%' }}
+      key={play}
+    >
+      <div style={{ height: 250, background: 'maroon', margin: 4 }}>
+        <div
+          style={{
+            left: '50%',
+            position: 'relative',
+            top: '50%',
+            transform: 'translate(-50%, -50%)',
+            width: 'fit-content',
+          }}
+        >
+          <h1>{description}</h1>
+        </div>
+      </div>
+    </button>
+    )
+  }
+
+
   render() {
-    const { choosePlay, afterOpponent } = this.props;
+    const { afterOpponent, choosePlay } = this.props;
+    const renderChooseButton = this.renderChooseButton;
 
     return (
       <div style={{ maxWidth: '90%', margin: 'auto' }}>
@@ -21,28 +49,9 @@ export default class SelectPlayStep extends React.PureComponent<Props> {
           </h1>
         </div>
         <div style={{ width: '100%' }}>
-          {Object.keys(Play).filter(key => !isNaN(Number(key))).map(option => (
-            <button
-              type="button"
-              onClick={() => choosePlay(Play[option])}
-              style={{ display: 'inline-block', width: '33%' }}
-              key={option}
-            >
-              <div style={{ height: 250, background: 'maroon', margin: 4 }}>
-                <div
-                  style={{
-                    left: '50%',
-                    position: 'relative',
-                    top: '50%',
-                    transform: 'translate(-50%, -50%)',
-                    width: 'fit-content',
-                  }}
-                >
-                  <h1>{Play[option]}</h1>
-                </div>
-              </div>
-            </button>
-          ))}
+          { renderChooseButton(choosePlay, Play.Rock, "Rock") }
+          { renderChooseButton(choosePlay, Play.Paper, "Paper") }
+          { renderChooseButton(choosePlay, Play.Scissors, "Scissors") }
         </div>
       </div>
     );

--- a/src/containers/GameContainer.ts
+++ b/src/containers/GameContainer.ts
@@ -21,3 +21,4 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps,
 )(GameController);
+

--- a/src/containers/GameContainer.ts
+++ b/src/containers/GameContainer.ts
@@ -11,7 +11,7 @@ const mapStateToProps = (state: ApplicationState) => ({
 });
 
 const mapDispatchToProps = {
-  chooseAPlay: GameAction.chooseAPlay,
+  choosePlay: GameAction.choosePlay,
   chooseOpponent: GameAction.chooseOpponent,
   subscribeOpponents: OpponentAction.subscribeOpponents,
   playComputer: GameAction.playComputer,

--- a/src/game-engine/application-states/index.ts
+++ b/src/game-engine/application-states/index.ts
@@ -1,5 +1,8 @@
-import { PlayerAState } from './PlayerA';
-import { PlayerBState } from './PlayerB';
+import { PlayerAState as A } from './PlayerA';
+import { PlayerBState as B } from './PlayerB';
+
+export type PlayerAState = A;
+export type PlayerBState = B;
 
 export type State = PlayerAState | PlayerBState;
 

--- a/src/redux/actions/game.ts
+++ b/src/redux/actions/game.ts
@@ -5,7 +5,7 @@ import { State } from '../../game-engine/application-states';
 
 export enum GameActionType {
   CHOOSE_OPPONENT = 'GAME.CHOOSE_OPPONENT',
-  CHOOSE_A_PLAY = 'GAME.CHOOSE_A_PLAY',
+  CHOOSE_PLAY = 'GAME.CHOOSE_PLAY',
   EVENT_RECEIVED = 'GAME.EVENT_RECEIVED',
   MOVE_RECEIVED = 'GAME.MOVE_RECEIVED',
   MOVE_SENT = 'GAME.MOVE_SENT',
@@ -25,9 +25,9 @@ export const GameAction = {
     stake,
   }),
 
-  chooseAPlay: (aPlay: Play) => ({
-    type: GameActionType.CHOOSE_A_PLAY as typeof GameActionType.CHOOSE_A_PLAY,
-    aPlay,
+  choosePlay: (play: Play) => ({
+    type: GameActionType.CHOOSE_PLAY as typeof GameActionType.CHOOSE_PLAY,
+    play,
   }),
 
   moveReceived: (move: Move) => ({

--- a/src/redux/actions/game.ts
+++ b/src/redux/actions/game.ts
@@ -52,10 +52,10 @@ export const GameAction = {
 };
 
 export type ChooseOpponentAction = ReturnType<typeof GameAction.chooseOpponent>;
-export type ChooseAPlayAction = ReturnType<typeof GameAction.chooseAPlay>;
+export type ChoosePlayAction = ReturnType<typeof GameAction.choosePlay>;
 export type MoveReceivedAction = ReturnType<typeof GameAction.moveReceived>;
 export type MoveSentAction = ReturnType<typeof GameAction.moveSent>;
 export type EventReceivedAction = ReturnType<typeof GameAction.eventReceived>;
 export type StateChangedAction = ReturnType<typeof GameAction.stateChanged>;
 export type PlayComputerAction = ReturnType<typeof GameAction.playComputer>;
-export type GameAction = ChooseOpponentAction | ChooseAPlayAction | MoveReceivedAction | MoveSentAction | EventReceivedAction | StateChangedAction | PlayComputerAction;
+export type GameAction = ChooseOpponentAction | ChoosePlayAction | MoveReceivedAction | MoveSentAction | EventReceivedAction | StateChangedAction | PlayComputerAction;

--- a/src/redux/sagas/application-controller.ts
+++ b/src/redux/sagas/application-controller.ts
@@ -40,8 +40,8 @@ export default function* applicationControllerSaga(wallet: ChannelWallet) {
         case GameActionType.MOVE_SENT:
           newState = gameEngine.moveSent();
           break;
-        case GameActionType.CHOOSE_A_PLAY:
-          newState = gameEngine.choosePlay(action.aPlay);
+        case GameActionType.CHOOSE_PLAY:
+          newState = gameEngine.choosePlay(action.play);
           break;
         case GameActionType.EVENT_RECEIVED:
           newState = gameEngine.receiveEvent(action.event);


### PR DESCRIPTION
This PR adds the `playerBstates` to the game controller, so that screens will display for them. There's still a lot of work to be done here but this PR puts the basic structure in place.

It also renames the `ChooseAPlay` action to `ChoosePlay`, so that it can be used for both players. 