### PR TITLE
Revert logic and add a simple check for !exists instead

### DIFF
--- a/src/redux/sagas/wallet.ts
+++ b/src/redux/sagas/wallet.ts
@@ -44,7 +44,9 @@ function* fetchWallet(uid: string) {
   // It seems like rsf.database.read doesn't really work when the result is a collection
 
   const result = yield call([query, query.once], 'value');
-  const wallet  = walletTransformer(result); // There should only be 1 wallet returned
+  if (!result.exists()) { return null };
+  let wallet;
+  result.forEach((data) => { wallet = walletTransformer(data); }); // result should have size 1
 
   return new ChannelWallet(wallet.privateKey);
 }


### PR DESCRIPTION
It looks like my original change would spawn additional players for a user. Not sure why the query returned a `wallet` before and now returns a collection of `wallet`s but that seems to be the case. 

I've reverted the change and just added a simple `!exists()` check and things seem to be working (in both the case of existing players and wallets and when they do not exist for a user)