### PR TITLE
Change result outcomes to YouWin/YouLose

### DIFF
--- a/src/game-engine/GameEngineA.ts
+++ b/src/game-engine/GameEngineA.ts
@@ -243,7 +243,7 @@ export default class GameEngineA {
     if (result === Result.Tie) {
       balances[0] += stake;
       balances[1] -= stake;
-    } else if (result === Result.AWon) {
+    } else if (result === Result.YouWin) {
       balances[0] += 2 * stake;
       balances[1] -= 2 * stake;
     }

--- a/src/game-engine/GameEngineB.ts
+++ b/src/game-engine/GameEngineB.ts
@@ -247,7 +247,7 @@ export default class GameEngineB {
 
     const nextPosition = new Resting(channel, turnNum, balances, stake);
     const move = this.channelWallet.sign(nextPosition.toHex());
-    const result = calculateResult(aPlay, bPlay);
+    const result = calculateResult(bPlay, aPlay);
 
     return this.transitionTo(
       new State.ReadyToSendResting({

--- a/src/game-engine/__tests__/HappyPathEndToEnd.test.ts
+++ b/src/game-engine/__tests__/HappyPathEndToEnd.test.ts
@@ -165,7 +165,7 @@ it('runthrough', () => {
   expect(readyToSendReveal.aPlay).toEqual(Play.Rock);
   expect(readyToSendReveal.bPlay).toEqual(Play.Scissors);
   expect(readyToSendReveal.salt).toEqual(waitForAccept.salt);
-  expect(readyToSendReveal.result).toEqual(Result.AWon);
+  expect(readyToSendReveal.result).toEqual(Result.YouWin);
 
   const move6 = readyToSendReveal.move;
   const gameState6 = pledgeFromHex(move6.state) as positions.Reveal;

--- a/src/game-engine/application-states/PlayerA/__tests__/index.test.ts
+++ b/src/game-engine/application-states/PlayerA/__tests__/index.test.ts
@@ -19,7 +19,7 @@ const aPlay = Play.Rock;
 const bPlay = Play.Scissors;
 const salt = "abc123";
 const move = new Move('state', 'signature'); // fake move
-const result = Result.AWon;
+const result = Result.YouWin;
 
 const itHasSharedFunctionality = (appState) => {
   it("returns myAddress", () => {

--- a/src/game-engine/application-states/PlayerB/__tests__/index.test.ts
+++ b/src/game-engine/application-states/PlayerB/__tests__/index.test.ts
@@ -19,7 +19,7 @@ const aPlay = Play.Rock;
 const bPlay = Play.Scissors;
 const salt = "abc123";
 const move = new Move('state', 'signature'); // fake move
-const result = Result.AWon;
+const result = Result.YouWin;
 
 const itHasSharedFunctionality = (appState) => {
   it("returns myAddress", () => {

--- a/src/game-engine/positions/index.ts
+++ b/src/game-engine/positions/index.ts
@@ -34,8 +34,8 @@ export enum Play {
 
 export enum Result {
   Tie,
-  AWon,
-  BWon,
+  YouWin,
+  YouLose,
 }
 
 export function packRestingAttributes(stake: number) {
@@ -89,9 +89,9 @@ export function calculateResult(aPlay: Play, bPlay: Play) {
   const x = ((aPlay - bPlay) + 2) % 3;
   switch(x) {
     case 0:
-      return Result.AWon;
+      return Result.YouWin;
     case 1:
-      return Result.BWon;
+      return Result.YouLose;
     default:
       return Result.Tie;
   }

--- a/src/game-engine/positions/result.test.ts
+++ b/src/game-engine/positions/result.test.ts
@@ -1,19 +1,19 @@
 import { Play, Result, calculateResult } from '.';
 
-function testOutcome(aPlay: Play, bPlay: Play, expectedResult: Result) {
-  it(`Gives ${Result[expectedResult]} when a plays ${Play[aPlay]} and b plays ${Play[bPlay]}`, () => {
-    expect(calculateResult(aPlay, bPlay)).toEqual(expectedResult);
+function testOutcome(yourPlay: Play, theirPlay: Play, expectedResult: Result) {
+  it(`Gives ${Result[expectedResult]} when you play ${Play[yourPlay]} and they play ${Play[theirPlay]}`, () => {
+    expect(calculateResult(yourPlay, theirPlay)).toEqual(expectedResult);
   });
 }
 
 describe('result', () => {
   testOutcome(Play.Rock, Play.Rock, Result.Tie);
-  testOutcome(Play.Rock, Play.Paper, Result.BWon);
-  testOutcome(Play.Rock, Play.Scissors, Result.AWon);
-  testOutcome(Play.Paper, Play.Rock, Result.AWon);
+  testOutcome(Play.Rock, Play.Paper, Result.YouLose);
+  testOutcome(Play.Rock, Play.Scissors, Result.YouWin);
+  testOutcome(Play.Paper, Play.Rock, Result.YouWin);
   testOutcome(Play.Paper, Play.Paper, Result.Tie);
-  testOutcome(Play.Paper, Play.Scissors, Result.BWon);
-  testOutcome(Play.Scissors, Play.Rock, Result.BWon);
-  testOutcome(Play.Scissors, Play.Paper, Result.AWon);
+  testOutcome(Play.Paper, Play.Scissors, Result.YouLose);
+  testOutcome(Play.Scissors, Play.Rock, Result.YouLose);
+  testOutcome(Play.Scissors, Play.Paper, Result.YouWin);
   testOutcome(Play.Scissors, Play.Scissors, Result.Tie);
 });


### PR DESCRIPTION
Whenever we use `Result` it's in the context of a given player. Rather than be constantly checking whether `(player == playerA && result == Result.AWon) || (player == playerB && result == Result.BWon)`, it's a lot easier to bake this into the result and just check whether `result == Result.YouWin`.