### PR TITLE
Fix smart contract tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
         
       # run tests!
-      - run: yarn test --all --ci
+      - run: yarn test:ci
 
 
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@
 
 `yarn run build`
 
-#### To run tests:
-
-`yarn run test`
-
 #### To develop smart contracts
 
 ```
@@ -27,10 +23,19 @@ yarn truffle:compile
 
 # deploy smart contracts to a network
 TRUFFLE_NETWORK=<named network in truffle.ts> yarn truffle:migrate
-
-# run truffle tests, contained in ./test
-yarn truffle:test
 ```
+
+#### To run application tests in watch mode:
+
+`yarn run test:app`
+
+#### To run smart contract tests:
+
+`yarn run test:truffle`
+
+#### To run all tests (before submitting a PR):
+
+`yarn run test`
 
 #### To update dependencies:
 

--- a/contracts/RockPaperScissorsGame.sol
+++ b/contracts/RockPaperScissorsGame.sol
@@ -109,7 +109,7 @@ contract RockPaperScissorsGame {
         require(hashed == _old.preCommit());
 
         // calculate winnings
-        (aWinnings, bWinnings) = winnings(_old.aPlay(), _old.bPlay(), _old.stake());
+        (aWinnings, bWinnings) = winnings(_new.aPlay(), _new.bPlay(), _new.stake());
 
         require(_new.aResolution() == _old.aResolution() + aWinnings);
         require(_new.bResolution() == _old.bResolution() - 2 * _old.stake() + bWinnings);

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "copy_truffle_files": "copyfiles './contracts/**/*' './migrations/**/*' ./build/dist",
     "copy_dotenv": "copyfiles '.env' ./build/dist",
     "truffle:compile": "tsc && tsc -p ./tsconfig.truffle.json && run-s copy_truffle_files && (cd build/dist && ../../node_modules/.bin/truffle compile)",
-    "truffle:migrate": "run-s truffle:compile copy_dotenv && (cd build/dist && ../../node_modules/.bin/truffle migrate --network $TRUFFLE_NETWORK)"
+    "truffle:migrate": "run-s truffle:compile copy_dotenv && (cd build/dist && ../../node_modules/.bin/truffle migrate --network ${TRUFFLE_NETWORK:development})"
   },
   "devDependencies": {
     "@babel/runtime": "^7.0.0-beta.53",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "run-s test:truffle 'test:app --all'",
+    "test:ci": "run-s test:truffle 'test:app --all --ci'",
     "test:app": "node scripts/test.js --env=jsdom",
     "test:truffle": "run-s truffle:compile && (cd build/dist && pwd && ../../scripts/run-with-ganache.sh)",
     "postinstall": "rm -f node_modules/web3/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js --env=jsdom",
+    "test:all": "run-s truffle:test 'test --all'",
     "postinstall": "rm -f node_modules/web3/index.d.ts",
     "copy_truffle_files": "copyfiles './contracts/**/*' './migrations/**/*' ./build/dist",
     "copy_dotenv": "copyfiles '.env' ./build/dist",

--- a/package.json
+++ b/package.json
@@ -56,14 +56,14 @@
   "scripts": {
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
-    "test": "node scripts/test.js --env=jsdom",
-    "test:all": "run-s truffle:test 'test --all'",
+    "test": "run-s test:truffle 'test:app --all'",
+    "test:app": "node scripts/test.js --env=jsdom",
+    "test:truffle": "run-s truffle:compile && (cd build/dist && pwd && ../../scripts/run-with-ganache.sh)",
     "postinstall": "rm -f node_modules/web3/index.d.ts",
     "copy_truffle_files": "copyfiles './contracts/**/*' './migrations/**/*' ./build/dist",
     "copy_dotenv": "copyfiles '.env' ./build/dist",
     "truffle:compile": "tsc && tsc -p ./tsconfig.truffle.json && run-s copy_truffle_files && (cd build/dist && ../../node_modules/.bin/truffle compile)",
-    "truffle:migrate": "run-s truffle:compile copy_dotenv && (cd build/dist && ../../node_modules/.bin/truffle migrate --network $TRUFFLE_NETWORK)",
-    "truffle:test": "run-s truffle:compile && (cd build/dist && pwd && ../../scripts/run-with-ganache.sh)"
+    "truffle:migrate": "run-s truffle:compile copy_dotenv && (cd build/dist && ../../node_modules/.bin/truffle migrate --network $TRUFFLE_NETWORK)"
   },
   "devDependencies": {
     "@babel/runtime": "^7.0.0-beta.53",

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -22,10 +22,10 @@ let argv = process.argv.slice(2);
 if (
   !process.env.CI &&
   argv.indexOf('--coverage') === -1 &&
-  argv.indexOf('--watchAll') === -1
+  argv.indexOf('--watchAll') === -1 && 
+  argv.indexOf('--all') === -1
 ) {
   argv.push('--watch');
 }
-
 
 jest.run(argv);

--- a/src/game-engine/positions/Propose.ts
+++ b/src/game-engine/positions/Propose.ts
@@ -1,7 +1,7 @@
 import { State } from 'fmg-core';
 import { packProposeAttributes, hashCommitment, Play } from '.';
 
-export default class Resting extends State {
+export default class Propose extends State {
   static createWithPlayAndSalt (
     channel,
     turnNum: number,
@@ -11,7 +11,7 @@ export default class Resting extends State {
     salt: string,
   ) {
     const preCommit = hashCommitment(aPlay, salt);
-    return new Resting(channel, turnNum, balances, stake, preCommit);
+    return new Propose(channel, turnNum, balances, stake, preCommit);
   }
 
   stake: number;

--- a/test/rps-state.ts
+++ b/test/rps-state.ts
@@ -1,32 +1,28 @@
-import { Channel, assertRevert } from 'fmg-core';
-import { RpsGame } from '../src/rock-paper-scissors';
+import { Channel } from 'fmg-core';
+import { Play, Reveal, Propose } from '../src/game-engine/positions';
 
-var RpsStateContract = artifacts.require("./RockPaperScissorsState.sol");
+const RpsStateContract = artifacts.require("./RockPaperScissorsState.sol");
 
-contract('RockPaperScissorsPositions', (accounts) => {
+contract('RockPaperScissorsState', (accounts) => {
 
   const preCommit = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
   const salt = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
   const turnNum = 4;
-  const resolution = [4, 5];
+  const balances = [4, 5];
   const stake = 2;
-  const aPlay = RpsGame.Plays.ROCK;
-  const bPlay = RpsGame.Plays.SCISSORS;
+  const aPlay = Play.Rock;
+  const bPlay = Play.Scissors;
 
   // Serializing / Deserializing
   // ===========================
 
-  let channel = new Channel("0xdeadbeef", 0, [accounts[0], accounts[1]]);
-  let original = RpsGame.revealState({
-    channel,
-    turnNum,
-    resolution,
-    stake,
-    preCommit,
-    aPlay,
-    bPlay,
-    salt,
-  });
+  const channel = new Channel("0xdeadbeef", 0, [accounts[0], accounts[1]]);
+  const propose = new Propose(
+    channel, turnNum, balances, stake, preCommit
+  )
+  const reveal = new Reveal(
+    channel, turnNum, balances, stake, aPlay, bPlay, salt
+  )
   
   let stateContract;
 
@@ -36,37 +32,37 @@ contract('RockPaperScissorsPositions', (accounts) => {
 
   // skipped because web3 can't cope with the positionType object that is returned
   it.skip("can parse positionType", async () => {
-    assert.equal(await stateContract.positionType(original.toHex()), original.positionType);
+    assert.equal(await stateContract.positionType(reveal.toHex()), 'some type');
   });
 
   it("can parse aBal", async () => {
-    assert.equal(await stateContract.aResolution(original.toHex()), resolution[0]);
+    assert.equal(await stateContract.aResolution(reveal.toHex()), balances[0]);
   });
 
   it("can parse bBal", async () => {
-    assert.equal(await stateContract.bResolution(original.toHex()), resolution[1]);
+    assert.equal(await stateContract.bResolution(reveal.toHex()), balances[1]);
   });
 
   it("can parse stake", async () => {
-    assert.equal(await stateContract.stake(original.toHex()), stake);
+    assert.equal(await stateContract.stake(reveal.toHex()), stake);
   });
 
   it("can parse preCommit", async () => {
-    assert.equal(await stateContract.preCommit(original.toHex()), preCommit);
+    assert.equal(await stateContract.preCommit(propose.toHex()), preCommit);
   });
 
   // skipped because web3 can't cope with the Play object that is returned
   it.skip("can parse bPlay", async () => {
-    assert.equal(await stateContract.bPlay.call(original.toHex()), bPlay);
+    assert.equal(await stateContract.bPlay.call(reveal.toHex()), bPlay);
   });
 
   // skipped because web3 can't cope with the Play object that is returned
   it.skip("can parse aPlay", async () => {
-    assert.equal(await stateContract.aPlay.call(original.toHex()), aPlay);
+    assert.equal(await stateContract.aPlay.call(reveal.toHex()), aPlay);
   });
 
   it("can parse salt", async () => {
-    assert.equal(await stateContract.salt(original.toHex()), salt);
+    assert.equal(await stateContract.salt(reveal.toHex()), salt);
   });
 
 });

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1,4 +1,5 @@
 declare var web3: any;
-declare var assert: any;
 declare var artifacts: any;
 declare var contract: any;
+declare var before: any;
+declare var assert: any;


### PR DESCRIPTION
We didn't run truffle tests for a long time, completely ignoring the
smart contracts. The application architecture changed significantly, so
the tests are updated accordingly.

The npm test scripts are re-jiggered. Truffle tests are now run by circleCI. To run application tests in watch mode, run `yarn test:app` instead.