### PR TITLE
Reformat actions

### DIFF
--- a/src/containers/HomePageContainer.ts
+++ b/src/containers/HomePageContainer.ts
@@ -1,15 +1,15 @@
 import { connect } from 'react-redux';
 
 import HomePage from '../components/HomePage';
-import { LoginAction } from '../redux/actions/login';
+import * as loginActions from '../redux/actions/login';
 
 const mapStateToProps = (state) => ({
   loggedIn: state.login.loggedIn,
 });
 
 const mapDispatchToProps = {
-  login: LoginAction.login,
-  logout: LoginAction.logout,
+  login: loginActions.loginRequest,
+  logout: loginActions.logoutRequest,
 };
 
 export default connect(

--- a/src/redux/actions/login.ts
+++ b/src/redux/actions/login.ts
@@ -1,59 +1,59 @@
-export enum LoginActionType {
-  LOGIN_REQUEST = 'LOGIN.REQUEST',
-  LOGIN_SUCCESS = 'LOGIN.SUCCESS',
-  LOGIN_FAILURE = 'LOGIN.FAILURE',
-  LOGOUT_REQUEST = 'LOGOUT.REQUEST',
-  LOGOUT_SUCCESS = 'LOGOUT.SUCCESS',
-  LOGOUT_FAILURE = 'LOGOUT.FAILURE',
-}
+// LOGIN
+// =====
 
-export const LoginAction = {
-  login: () => ({
-    type: LoginActionType.LOGIN_REQUEST as typeof LoginActionType.LOGIN_REQUEST,
-  }),
+export const LOGIN_REQUEST = 'LOGIN.REQUEST';
+export const LOGIN_SUCCESS = 'LOGIN.SUCCESS';
+export const LOGIN_FAILURE = 'LOGIN.FAILURE';
 
-  loginFailure: (error: Error) => ({
-    type: LoginActionType.LOGIN_FAILURE as typeof LoginActionType.LOGIN_FAILURE,
-    error,
-  }),
+export const loginRequest = () => ({
+  type: LOGIN_REQUEST as typeof LOGIN_REQUEST,
+});
 
-  logout: () => ({
-    type: LoginActionType.LOGOUT_REQUEST as typeof LoginActionType.LOGOUT_REQUEST,
-  }),
+export const loginSuccess = (user: object, player: { address: string; name: string; }) => ({
+  type: LOGIN_SUCCESS as typeof LOGIN_SUCCESS,
+  user,
+  player,
+});
 
-  logoutFailure: (error: Error) => ({
-    type: LoginActionType.LOGOUT_FAILURE as typeof LoginActionType.LOGOUT_FAILURE,
-    error,
-  }),
+export const loginFailure = (error: Error) => ({
+  type: LOGIN_FAILURE as typeof LOGIN_FAILURE,
+  error,
+});
 
-  loginSuccess: (
-    user: object,
-    player?: {
-      address: string;
-      name: string;
-    },
-  ) => ({
-    type: LoginActionType.LOGIN_SUCCESS as typeof LoginActionType.LOGIN_SUCCESS,
-    user,
-    player,
-  }),
+export type LoginRequest = ReturnType<typeof loginRequest>;
+export type LoginSuccess = ReturnType<typeof loginSuccess>;
+export type LoginFailure = ReturnType<typeof loginFailure>;
+export type LoginResponse = LoginSuccess | LoginFailure;
 
-  logoutSuccess: () => ({
-    type: LoginActionType.LOGOUT_SUCCESS as typeof LoginActionType.LOGOUT_SUCCESS,
-  }),
-};
+// LOGOUT
+// ======
 
-export type LoginRequestAction = ReturnType<typeof LoginAction.login>;
-export type LoginFailureAction = ReturnType<typeof LoginAction.loginFailure>;
-export type LogoutAction = ReturnType<typeof LoginAction.logout>;
-export type LogoutFailureAction = ReturnType<typeof LoginAction.logoutFailure>;
-export type LoginSuccessAction = ReturnType<typeof LoginAction.loginSuccess>;
-export type LogoutSuccessAction = ReturnType<typeof LoginAction.logoutSuccess>;
+export const LOGOUT_REQUEST = 'LOGOUT.REQUEST';
+export const LOGOUT_SUCCESS = 'LOGOUT.SUCCESS';
+export const LOGOUT_FAILURE = 'LOGOUT.FAILURE';
 
-export type LoginAction =
-  | LoginRequestAction
-  | LoginFailureAction
-  | LogoutAction
-  | LogoutFailureAction
-  | LoginSuccessAction
-  | LogoutSuccessAction;
+export const logoutRequest = () => ({
+  type: LOGOUT_REQUEST as typeof LOGOUT_REQUEST,
+});
+
+export const logoutSuccess = () => ({
+  type: LOGOUT_SUCCESS as typeof LOGOUT_SUCCESS,
+});
+
+export const logoutFailure = (error: Error) => ({
+  type: LOGOUT_FAILURE as typeof LOGOUT_FAILURE,
+  error,
+});
+
+export type LogoutRequest = ReturnType<typeof logoutRequest>;
+export type LogoutSuccess = ReturnType<typeof logoutSuccess>;
+export type LogoutFailure = ReturnType<typeof logoutFailure>;
+export type LogoutResponse = LogoutSuccess | LogoutFailure;
+
+
+// 
+
+export type RequestAction = LoginRequest | LogoutRequest;
+export type ResponseAction = LoginResponse | LogoutResponse;
+
+export type AnyAction = RequestAction | ResponseAction;

--- a/src/redux/reducers/login.ts
+++ b/src/redux/reducers/login.ts
@@ -1,5 +1,5 @@
 import { Reducer } from 'redux';
-import { LoginActionType, LoginAction } from '../actions/login';
+import * as loginActions from '../actions/login';
 
 export interface LoginState {
   loading: boolean;
@@ -18,15 +18,15 @@ const initialState: LoginState = {
   player: undefined,
 };
 
-export const loginReducer: Reducer<LoginState> = (state = initialState, action: LoginAction) => {
+export const loginReducer: Reducer<LoginState> = (state = initialState, action: loginActions.AnyAction) => {
   switch (action.type) {
-    case LoginActionType.LOGIN_REQUEST:
-    case LoginActionType.LOGOUT_REQUEST:
+    case loginActions.LOGIN_REQUEST:
+    case loginActions.LOGOUT_REQUEST:
       return {
         ...state,
         loading: true,
       };
-    case LoginActionType.LOGIN_SUCCESS:
+    case loginActions.LOGIN_SUCCESS:
       return {
         ...state,
         loading: false,
@@ -34,14 +34,14 @@ export const loginReducer: Reducer<LoginState> = (state = initialState, action: 
         user: action.user,
         player: action.player,
       };
-    case LoginActionType.LOGIN_FAILURE:
+    case loginActions.LOGIN_FAILURE:
       return {
         ...state,
         loading: false,
       };
-    case LoginActionType.LOGOUT_SUCCESS:
+    case loginActions.LOGOUT_SUCCESS:
       return initialState;
-    case LoginActionType.LOGOUT_FAILURE:
+    case loginActions.LOGOUT_FAILURE:
       return {
         ...state,
         loading: false,

--- a/src/redux/sagas/login.ts
+++ b/src/redux/sagas/login.ts
@@ -2,7 +2,7 @@ import firebase from 'firebase';
 import { call, fork, put, take, takeEvery, cancel, race } from 'redux-saga/effects';
 import { delay } from 'redux-saga'
 
-import { LoginAction, LoginActionType } from '../actions/login';
+import * as loginActions from '../actions/login';
 import { reduxSagaFirebase } from '../../gateways/firebase';
 import { fetchOrCreatePlayer } from './player';
 import applicationControllerSaga from './application-controller';
@@ -16,7 +16,7 @@ function* loginSaga() {
     yield call(reduxSagaFirebase.auth.signInWithPopup, authProvider);
     // successful login will trigger the loginStatusWatcher, which will update the state
   } catch (error) {
-    yield put(LoginAction.loginFailure(error));
+    yield put(loginActions.loginFailure(error));
   }
 }
 
@@ -25,7 +25,7 @@ function* logoutSaga() {
     yield call(reduxSagaFirebase.auth.signOut);
     // successful logout will trigger the loginStatusWatcher, which will update the state
   } catch (error) {
-    yield put(LoginAction.logoutFailure(error));
+    yield put(loginActions.logoutFailure(error));
   }
 }
 
@@ -58,14 +58,14 @@ function* loginStatusWatcherSaga() {
 
       applicationThread = yield fork(applicationControllerSaga, address);
 
-      yield put(LoginAction.loginSuccess(user, player));
+      yield put(loginActions.loginSuccess(user, player));
 
     } else {
       if (applicationThread) {
         yield cancel(applicationThread);
       }
       yield put(MessageAction.unsubscribeMessages());
-      yield put(LoginAction.logoutSuccess());
+      yield put(loginActions.logoutSuccess());
     }
   }
 }
@@ -73,7 +73,7 @@ function* loginStatusWatcherSaga() {
 export default function* loginRootSaga() {
   yield fork(loginStatusWatcherSaga);
   yield [
-    takeEvery(LoginActionType.LOGIN_REQUEST, loginSaga),
-    takeEvery(LoginActionType.LOGOUT_REQUEST, logoutSaga),
+    takeEvery(loginActions.LOGIN_REQUEST, loginSaga),
+    takeEvery(loginActions.LOGOUT_REQUEST, logoutSaga),
   ];
 }


### PR DESCRIPTION
Reformats the login actions to use the same convention as the wallet actions:

* Lowercase for the method that returns the action e.g. `loginRequest`
* Capitalized for the typescript type of the action e.g. `LoginRequest`
* Uppercase for the value of the `type` property on the action e.g. `LOGIN_REQUEST`

All of these are exported at the top level of the namespace.