### PR TITLE
Build first for test:ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "run-s test:truffle 'test:app --all'",
-    "test:ci": "run-s test:truffle 'test:app --all --ci'",
+    "test:ci": "run-s build test:truffle 'test:app --all --ci'",
     "test:app": "node scripts/test.js --env=jsdom",
     "test:truffle": "node scripts/test_truffle.js",
     "postinstall": "rm -f node_modules/web3/index.d.ts"


### PR DESCRIPTION
Build the application first to catch any compile errors or lint errors on ci