### PR TITLE
Fix crash when no redux addon present

### DIFF
--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -5,10 +5,9 @@ import reducer from './reducer';
 const sagaMiddleware = createSagaMiddleware();
 
 import loginSaga from './login/saga';
-
-const enhancers = compose(
+const composeEnhancers = (window as  any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+const enhancers = composeEnhancers(
   applyMiddleware(sagaMiddleware),
-  (window as any).__REDUX_DEVTOOLS_EXTENSION__ && (window as any).__REDUX_DEVTOOLS_EXTENSION__()
 );
 
 const store = createStore(reducer, enhancers);


### PR DESCRIPTION
Switched config to follow what is suggested here: https://github.com/zalmoxisus/redux-devtools-extension#12-advanced-store-setup

closes #160 