### PR TITLE
Allow the game to conclude (Part 1)

### DIFF
--- a/src/components/SelectPlayPage.tsx
+++ b/src/components/SelectPlayPage.tsx
@@ -8,6 +8,7 @@ import { faHandRock, faHandPaper, faHandScissors } from '@fortawesome/free-solid
 
 interface Props {
   choosePlay: (play: Play) => void;
+  abandonGame: () => void;
   afterOpponent?: any;
 }
 
@@ -29,7 +30,7 @@ export default class SelectPlayStep extends React.PureComponent<Props> {
   }
 
   render() {
-    const { afterOpponent, choosePlay } = this.props;
+    const { afterOpponent, choosePlay, abandonGame } = this.props;
     const renderChooseButton = this.renderChooseButton;
 
     return (
@@ -51,6 +52,11 @@ export default class SelectPlayStep extends React.PureComponent<Props> {
               {renderChooseButton(choosePlay, Play.Scissors, 'Scissors', <FontAwesomeIcon icon={faHandScissors} size='7x' flip="horizontal" />)}
             </div>
           </div>
+          <Button onClick={() => abandonGame()} color="dark" className="w-75 p-3">
+            <div className='mb-3'>
+              <h1>Abandon game</h1>
+            </div>
+          </Button>
         </div>
       </div>
     );

--- a/src/containers/GameContainer.tsx
+++ b/src/containers/GameContainer.tsx
@@ -41,7 +41,7 @@ function GameContainer(props: GameProps) {
       return <FundingConfirmedPage message="Waiting for your opponent to acknowledge" />;
 
     case playerA.CHOOSE_PLAY:
-      return <SelectPlayPage choosePlay={choosePlay} />;
+      return <SelectPlayPage choosePlay={choosePlay} abandonGame={abandonGame} />;
 
     case playerA.WAIT_FOR_ACCEPT:
       return (
@@ -70,6 +70,18 @@ function GameContainer(props: GameProps) {
         <WaitingStep message="About to conclude the game – either you or your opponent has run out of funds!" />
       );
 
+    case playerA.WAIT_FOR_CONCLUDE:
+      return (
+        <WaitingStep message="Waiting for opponent to conclude the game" />
+      );
+
+    case playerA.CONCLUDED:
+      // TODO: add withdraw button!
+      const message = `The game has concluded -- you may now withdraw your winnings of ${state.balances[state.playerIndex]} Finney! [Withdrawal not implemented]`
+      return (
+        <WaitingStep message={message} />
+      );
+
     case playerB.WAIT_FOR_FUNDING:
       return <WalletController />;
 
@@ -80,7 +92,7 @@ function GameContainer(props: GameProps) {
       return <WaitingStep message="Waiting for your opponent to choose their move" />;
 
     case playerB.CHOOSE_PLAY:
-      return <SelectPlayPage choosePlay={choosePlay} />;
+      return <SelectPlayPage choosePlay={choosePlay} abandonGame={abandonGame} />;
 
     case playerB.WAIT_FOR_REVEAL:
       return (

--- a/src/game-engine/GameEngineA.ts
+++ b/src/game-engine/GameEngineA.ts
@@ -110,28 +110,25 @@ export default class GameEngineA {
   }
 
   conclude() {
-    // problem - we don't necessarily have all the stuff here :()
+    if (this.state instanceof State.Concluded) {
+      return this.state;
+    }
 
-    // const concludePledge = new Conclude(
-    //   oldState.channel,
-    //   oldPledge.turnNum + 1,
-    //   oldState.balances
-    // );
+    const { channel, balances, turnNum } = this.state;
+    const conclude = new Conclude(channel, turnNum + 1, balances)
+    if (this.state instanceof State.WaitForConclude) {
+      return this.transitionTo(
+        new State.Concluded({
+          position: conclude,
+        })
+      );
+    }
 
-    // const concludeMove = this.channelWallet.sign(concludePledge.toHex());
-
-    // if (oldPledge.turnNum % 2 === 0) {
-    //   newState = new State.ReadyToSendConcludeA({
-    //     ...oldState.commonAttributes,
-    //     move: concludeMove,
-    //   });
-    // } else if (oldPledge.turnNum % 2 === 1) {
-    //   newState = new ApplicationStatesB.ReadyToSendConcludeB({
-    //     ...oldState.commonAttributes,
-    //     move: concludeMove,
-    //   });
-    // }
-    return this.state;
+    return this.transitionTo(
+      new State.WaitForConclude({
+        position: conclude,
+      })
+    );
   }
 
   transitionTo(state) {
@@ -197,6 +194,14 @@ export default class GameEngineA {
   }
 
   receivedConclude(position: Conclude) {
+    if (this.state instanceof State.Concluded) {
+      return this.state;
+    }
+    if (this.state instanceof State.WaitForConclude) {
+      return this.transitionTo(
+        new State.Concluded({ position })
+      )
+    }
     // todo: need a move. Might also need an intermediate state here
     return this.transitionTo(
       new State.WaitForConclude({ position })

--- a/src/game-engine/application-states/PlayerA/index.ts
+++ b/src/game-engine/application-states/PlayerA/index.ts
@@ -22,6 +22,7 @@ export enum PlayerAStateType {
   WAIT_FOR_ACCEPT = 'PLAYER_A.WAIT_FOR_ACCEPT',
   WAIT_FOR_RESTING = 'PLAYER_A.WAIT_FOR_RESTING',
   WAIT_FOR_CONCLUDE = 'PLAYER_A.WAIT_FOR_CONCLUDE',
+  CONCLUDED = 'PLAYER_A.CONCLUDED',
   INSUFFICIENT_FUNDS = 'PLAYER_A.INSUFFICIENT_FUNDS',
 }
 
@@ -116,6 +117,11 @@ export class WaitForConclude extends BasePlayerA<Conclude> {
   readonly isReadyToSend = false;
 }
 
+export class Concluded extends BasePlayerA<Conclude> {
+  readonly type = PlayerAStateType.CONCLUDED;
+  readonly isReadyToSend = false;
+}
+
 export type PlayerAState =
   | WaitForPreFundSetup
   | WaitForFunding
@@ -124,4 +130,5 @@ export type PlayerAState =
   | WaitForAccept
   | WaitForResting
   | InsufficientFunds
-  | WaitForConclude;
+  | WaitForConclude
+  | Concluded;

--- a/src/game-engine/application-states/PlayerB/index.ts
+++ b/src/game-engine/application-states/PlayerB/index.ts
@@ -21,6 +21,7 @@ export enum PlayerBStateType {
   WAIT_FOR_CONCLUDE = 'PLAYER_B.WAIT_FOR_CONCLUDE',
   VIEW_RESULT = 'PLAYER_B.VIEW_RESULT',
   INSUFFICIENT_FUNDS = 'PLAYER_B.INSUFFICIENT_FUNDS',
+  CONCLUDED = 'PLAYER_B.CONCLUDED',
 }
 
 class BasePlayerB<T extends Position> extends BaseState<T> {
@@ -93,6 +94,11 @@ export class WaitForConclude extends BasePlayerB<Conclude> {
   readonly isReadyToSend = false;
 }
 
+export class Concluded extends BasePlayerB<Conclude> {
+  readonly type = PlayerBStateType.CONCLUDED;
+  readonly isReadyToSend = false;
+}
+
 export type PlayerBState = (
   | WaitForFunding
   | WaitForPostFundSetup
@@ -102,4 +108,5 @@ export type PlayerBState = (
   | ViewResult
   | InsufficientFunds
   | WaitForConclude
+  | Concluded
 );

--- a/src/redux/game/saga.ts
+++ b/src/redux/game/saga.ts
@@ -32,7 +32,6 @@ export default function* gameSaga(gameEngine: GameEngine) {
 
     switch (action.type) {
       case messageActions.MESSAGE_RECEIVED:
-        gameEngine.fundingConfirmed();
         newState = gameEngine.receivePosition(positionFromHex(action.message));
         break;
       case gameActions.CHOOSE_PLAY:

--- a/src/redux/game/saga.ts
+++ b/src/redux/game/saga.ts
@@ -74,6 +74,11 @@ function* processState(state) {
     case PlayerAStateType.CHOOSE_PLAY:
     case PlayerBStateType.CHOOSE_PLAY:
       break; // don't send anything if the next step is to ChoosePlay
+    case PlayerAStateType.CONCLUDED:
+    case PlayerBStateType.CONCLUDED:
+      yield put(walletActions.withdrawalRequest(state));
+      // Once the game is concluded, the players do not need to interact with each other
+      break;
     default:
       yield sendState(state);
   }

--- a/src/wallet/redux/actions/external.ts
+++ b/src/wallet/redux/actions/external.ts
@@ -1,5 +1,11 @@
-import { WaitForFunding as WaitForFundingA } from '../../../game-engine/application-states/PlayerA';
-import { WaitForFunding as WaitForFundingB } from '../../../game-engine/application-states/PlayerB';
+import {
+  WaitForFunding as WaitForFundingA, 
+  Concluded as ConcludedA, 
+} from '../../../game-engine/application-states/PlayerA';
+import {
+  WaitForFunding as WaitForFundingB, 
+  Concluded as ConcludedB, 
+} from '../../../game-engine/application-states/PlayerB';
 
 // FUNDING
 // =======
@@ -84,6 +90,33 @@ export type SignatureSuccess = ReturnType<typeof signatureSuccess>;
 export type SignatureFailure = ReturnType<typeof signatureFailure>;
 export type SignatureResponse = SignatureSuccess | SignatureFailure;
 
+// WITHDRAWAL
+// ==========
+
+export const WITHDRAWAL_REQUEST = 'WALLET.WITHDRAWAL.REQUEST';
+export const WITHDRAWAL_SUCCESS = 'WALLET.WITHDRAWAL.SUCCESS';
+export const WITHDRAWAL_FAILURE = 'WALLET.WITHDRAWAL.FAILURE';
+
+export const withdrawalRequest = (state: ConcludedA | ConcludedB) => ({
+  type: WITHDRAWAL_REQUEST as typeof WITHDRAWAL_REQUEST,
+  state,
+});
+export const withdrawalSuccess = channelId => ({
+  type: WITHDRAWAL_SUCCESS as typeof WITHDRAWAL_SUCCESS,
+  channelId,
+});
+export const withdrawalFailure = (channelId, reason) => ({
+  type: WITHDRAWAL_FAILURE as typeof WITHDRAWAL_FAILURE,
+  channelId,
+  reason,
+});
+
+export type WithdrawalRequest = ReturnType<typeof withdrawalRequest>;
+export type WithdrawalSuccess = ReturnType<typeof withdrawalSuccess>;
+export type WithdrawalFailure = ReturnType<typeof withdrawalFailure>;
+export type WithdrawalResponse = FundingSuccess | FundingFailure;
+
+
 // INITIALIZATION
 // ==============
 
@@ -99,7 +132,7 @@ export type InitializationSuccess = ReturnType<typeof initializationSuccess>;
 // Requests
 // ========
 
-export type RequestAction = FundingRequest | SignatureRequest | ValidationRequest;
+export type RequestAction = FundingRequest | SignatureRequest | ValidationRequest | WithdrawalRequest;
 
 // MESSAGING
 // =========


### PR DESCRIPTION
## Conclusions Part 1
Two application states are added -- `WaitForConclude` and `Concluded`.
The game engine transitions to these states when either
- its `conclude` method is called directly, following a user action
- it receives a `Conclude` position from the opponent. (As the opponent has signaled that they wish to end the game, it doesn't make sense for the game engine to try to progress the game.)
## Coming in Part 2
Once the game has reached a `Concluded` state, the game saga puts a `withdrawalRequest` action.

Initially, the wallet saga could take this action, and automatically withdraw money from the contract on the user's behalf.

## Coming in Part 3
You should be able to conclude the game from any screen, since this is supported by the ForceMoveGame protocol.

Player B conclusion views should be written.