### PR TITLE
dry up icons and polish spacing

### DIFF
--- a/src/components/CreateChallenge.tsx
+++ b/src/components/CreateChallenge.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 export default class CreateChallenge extends React.PureComponent<Props> {
   wagerInput: any;
-  nameInput: any = "";
+  nameInput: any = '';
 
   constructor(props) {
     super(props);
@@ -42,24 +42,40 @@ export default class CreateChallenge extends React.PureComponent<Props> {
 
   render() {
     return (
-      <form onSubmit={(e) => this.createChallengeHandler(e)}>
-        <div className='row'>
-          <div className='form-group col-sm-6'>
+      <form onSubmit={e => this.createChallengeHandler(e)}>
+        <div className="row">
+          <div className="form-group col-sm-6">
             <label htmlFor="name">Name</label>
-            <input className="form-control" type="text" name="name" id="name" placeholder="Name" ref={this.nameInput} />
+            <input
+              className="form-control"
+              type="text"
+              name="name"
+              id="name"
+              placeholder="Name"
+              ref={this.nameInput}
+            />
             <small id="passwordHelpBlock" className="form-text text-muted">
               The name that will show to other players in the challenge list.
             </small>
           </div>
-          <div className='form-group col-sm-6'>
+          <div className="form-group col-sm-6">
             <label htmlFor="wager">Wager</label>
-            <input className="form-control" type="number" name="wager" id="wager" placeholder="5" ref={this.wagerInput} />
+            <input
+              className="form-control"
+              type="number"
+              name="wager"
+              id="wager"
+              placeholder="5"
+              ref={this.wagerInput}
+            />
             <small id="passwordHelpBlock" className="form-text text-muted">
               Your wager in Finney.
             </small>
           </div>
         </div>
-        <Button type="submit" block={true} color="primary">Create Challenge</Button>
+        <Button type="submit" block={true} color="primary">
+          Create Challenge
+        </Button>
       </form>
     );
   }

--- a/src/components/FundingConfirmedPage.tsx
+++ b/src/components/FundingConfirmedPage.tsx
@@ -9,10 +9,10 @@ export default class FundingConfirmedPage extends React.PureComponent<Props> {
     const { message } = this.props;
 
     return (
-      <div className='container centered-container'>
-        <div className='w-100 text-center mb-5'>
-          <h1 className='mb-5'>Funding Confirmed!</h1>
-          <p className='lead'>{message}</p>
+      <div className="container centered-container">
+        <div className="w-100 text-center mb-5">
+          <h1 className="mb-5">Funding Confirmed!</h1>
+          <p className="lead">{message}</p>
         </div>
       </div>
     );

--- a/src/components/GameProposedPage.tsx
+++ b/src/components/GameProposedPage.tsx
@@ -9,10 +9,10 @@ export default class ProposeGamePage extends React.PureComponent<Props> {
     const { message } = this.props;
 
     return (
-      <div className='container centered-container'>
-        <div className='w-100 text-center mb-5'>
-          <h1 className='mb-5'>Game Proposed!</h1>
-          <p className='lead'>{message}</p>
+      <div className="container centered-container">
+        <div className="w-100 text-center mb-5">
+          <h1 className="mb-5">Game Proposed!</h1>
+          <p className="lead">{message}</p>
         </div>
       </div>
     );

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -3,8 +3,8 @@ import { StyleSheet, css } from 'aphrodite';
 
 import { Button } from 'reactstrap';
 
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faHandRock, faHandPaper, faHandScissors } from '@fortawesome/free-solid-svg-icons';
+import { Play } from '../game-engine/positions';
+import MoveIcon from './MoveIcon';
 
 interface IProps {
   login: () => any;
@@ -12,28 +12,30 @@ interface IProps {
 
 const HomePage: React.SFC<IProps> = ({ login }) => {
   return (
-    <div className='container centered-container'>
-      <div className='w-100'>
+    <div className="container centered-container">
+      <div className="w-100">
         <div className="mb-5 text-center">
           <h1 className={css(styles.title)}>Rock, Paper, Scissors</h1>
           <p>
             <em>A State Channel Game</em>
           </p>
         </div>
-        <div className='row text-center mb-5'>
-          <div className='col-sm-4'>
-            <FontAwesomeIcon icon={faHandRock} size='7x' rotation={90} />
+        <div className="row text-center mb-5">
+          <div className="col-sm-4">
+            <MoveIcon play={Play.Rock} />
           </div>
-          <div className='col-sm-4'>
-            <FontAwesomeIcon icon={faHandPaper} size='7x' rotation={90} />
+          <div className="col-sm-4">
+            <MoveIcon play={Play.Paper} />
           </div>
-          <div className='col-sm-4'>
-            <FontAwesomeIcon icon={faHandScissors} size='7x' flip="horizontal" />
+          <div className="col-sm-4">
+            <MoveIcon play={Play.Scissors} />
           </div>
         </div>
-        <div className='row mb-5'>
-          <div className='col-sm-12'>
-            <Button block={true} color="primary" onClick={login}>Login</Button>
+        <div className="row mb-5">
+          <div className="col-sm-12">
+            <Button block={true} color="primary" onClick={login}>
+              Login
+            </Button>
           </div>
         </div>
       </div>

--- a/src/components/LobbyPage.tsx
+++ b/src/components/LobbyPage.tsx
@@ -9,10 +9,10 @@ import { Button, ButtonGroup } from 'reactstrap';
 import BN from 'bn.js';
 
 interface Props {
-  challenges: Challenge[],
-  acceptChallenge: (address: string, stake: BN) => void,
-  createChallenge: (name: string, stake: BN) => void,
-  logoutRequest: () => void,
+  challenges: Challenge[];
+  acceptChallenge: (address: string, stake: BN) => void;
+  createChallenge: (name: string, stake: BN) => void;
+  logoutRequest: () => void;
 }
 
 const initialState = { showChallenges: true };
@@ -31,13 +31,25 @@ export default class ChallengePage extends React.PureComponent<Props, State> {
 
   render() {
     return (
-      <div className='container centered-container'>
-        <div className='w-100'>
-          <ButtonGroup className='d-flex w-100 mb-3'>
-            <Button className='w-50' outline={!this.state.showChallenges} onClick={this.showChallengesList}>Select an opponent</Button>
-            <Button className='w-50' outline={this.state.showChallenges} onClick={this.showCreateChallenge}>Create a challenge</Button>
+      <div className="container centered-container">
+        <div className="w-100">
+          <ButtonGroup className="d-flex w-100 mb-3">
+            <Button
+              className="w-50"
+              outline={!this.state.showChallenges}
+              onClick={this.showChallengesList}
+            >
+              Select an opponent
+            </Button>
+            <Button
+              className="w-50"
+              outline={this.state.showChallenges}
+              onClick={this.showCreateChallenge}
+            >
+              Create a challenge
+            </Button>
           </ButtonGroup>
-          <div className='mb-5'>
+          <div className="mb-5">
             {this.renderCreateChallenge()}
             {this.renderChallengesList()}
           </div>
@@ -60,11 +72,7 @@ export default class ChallengePage extends React.PureComponent<Props, State> {
       return null;
     }
 
-    return (
-      <CreateChallenge
-        createChallenge={this.props.createChallenge}
-      />
-    );
+    return <CreateChallenge createChallenge={this.props.createChallenge} />;
   }
 
   renderChallengesList() {

--- a/src/components/MetamaskErrorPage.tsx
+++ b/src/components/MetamaskErrorPage.tsx
@@ -14,19 +14,29 @@ export default function MetamaskErrorPage(props: MetamaskErrorProps) {
     42: 'kovan',
     4: 'rinkeby',
   };
-  let message = <span>This site needs to be connected to an ethereum wallet to function. If you have metamask, enable it now. If not, you can download a copy <a className={css(styles.link)} href="https://metamask.io/">here</a>.</span>;
+  let message = (
+    <span>
+      This site needs to be connected to an ethereum wallet to function. If you have metamask,
+      enable it now. If not, you can download a copy{' '}
+      <a className={css(styles.link)} href="https://metamask.io/">
+        here
+      </a>
+      .
+    </span>
+  );
   if (props.error.errorType === 'WrongNetwork' && props.error.networkId) {
     const type = networksTypes[props.error.networkId] || 'development';
-    message = <span>{`The wrong network is selected in your ethereum wallet. Please select the ${type} network in your ethereum wallet.`}</span>;
+    message = (
+      <span
+      >{`The wrong network is selected in your ethereum wallet. Please select the ${type} network in your ethereum wallet.`}</span>
+    );
   }
 
   return (
     <div className={css(styles.container)}>
       <div className={css(styles.headerText)}>
         <h1 className={css(styles.title)}>Ethereum Wallet Error</h1>
-        <p>
-          {message}
-        </p>
+        <p>{message}</p>
       </div>
     </div>
   );
@@ -42,7 +52,7 @@ const styles = StyleSheet.create({
     paddingBottom: 32,
   },
   link: {
-    color: "unset",
+    color: 'unset',
   },
   title: {
     marginBottom: 0,

--- a/src/components/MoveIcon.tsx
+++ b/src/components/MoveIcon.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faHandRock, faHandPaper, faHandScissors } from '@fortawesome/free-solid-svg-icons';
+
+import { Play } from '../game-engine/positions';
+
+export default function MoveIcon({ play }: { play: Play }) {
+  switch (play) {
+    case Play.Rock:
+      return (
+        <FontAwesomeIcon style={{ marginLeft: -30 }} icon={faHandRock} size="7x" rotation={90} />
+      );
+    case Play.Paper:
+      return (
+        <FontAwesomeIcon style={{ marginLeft: -30 }} icon={faHandPaper} size="7x" rotation={90} />
+      );
+    case Play.Scissors:
+      return (
+        <FontAwesomeIcon
+          style={{ marginLeft: -20 }}
+          icon={faHandScissors}
+          size="7x"
+          flip="horizontal"
+        />
+      );
+  }
+}

--- a/src/components/PlaySelectedPage.tsx
+++ b/src/components/PlaySelectedPage.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faHandRock, faHandPaper, faHandScissors } from '@fortawesome/free-solid-svg-icons';
 import { Play } from '../game-engine/positions';
+import MoveIcon from './MoveIcon';
 
 interface Props {
   message: string;
@@ -14,29 +13,19 @@ export default class PlaySelectedPage extends React.PureComponent<Props> {
     selectedPlayId: null,
   };
 
-  renderMoveIcon(play: Play) {
-    switch (play) {
-      case Play.Rock:
-        return <FontAwesomeIcon icon={faHandRock} size='7x' rotation={90} />;
-      case Play.Paper:
-        return <FontAwesomeIcon icon={faHandPaper} size='7x' rotation={90} />;
-      case Play.Scissors:
-        return <FontAwesomeIcon icon={faHandScissors} size='7x' flip="horizontal" />;
-    }
-  }
-
-
   render() {
     const { message, yourPlay } = this.props;
 
     return (
-      <div className='container centered-container'>
-        <div className='w-100 text-center mb-5'>
-          <h1 className='mb-5'>Move Chosen!</h1>
-          <p className='lead'>You chose <strong>{Play[yourPlay]}</strong></p>
+      <div className="container centered-container">
+        <div className="w-100 text-center mb-5">
+          <h1 className="mb-5">Move chosen!</h1>
+          <p className="lead">
+            You chose <strong>{Play[yourPlay]}</strong>
+          </p>
 
-          <div className='mb-5'>
-            {this.renderMoveIcon(yourPlay)}
+          <div className="mb-5">
+            <MoveIcon play={yourPlay} />
           </div>
 
           <p>{message}</p>

--- a/src/components/ResultPage.tsx
+++ b/src/components/ResultPage.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faHandRock, faHandPaper, faHandScissors } from '@fortawesome/free-solid-svg-icons';
 import { Button } from 'reactstrap';
 
 import { Play, Result } from '../game-engine/positions';
 import FooterBar from './FooterBar';
+import MoveIcon from './MoveIcon';
 
 interface Props {
   yourPlay: Play;
@@ -22,24 +21,13 @@ export default class ResultPage extends React.PureComponent<Props> {
 
     switch (result) {
       case Result.YouWin:
-        return "You won! 🎉";
+        return 'You won! 🎉';
 
       case Result.YouLose:
-        return "You lost 😭";
+        return 'You lost 😭';
 
       default:
         return "It's a tie! 🙄";
-    }
-  }
-
-  renderMoveIcon(play: Play) {
-    switch (play) {
-      case Play.Rock:
-        return <FontAwesomeIcon icon={faHandRock} size='7x' rotation={90} />;
-      case Play.Paper:
-        return <FontAwesomeIcon icon={faHandPaper} size='7x' rotation={90} />;
-      case Play.Scissors:
-        return <FontAwesomeIcon icon={faHandScissors} size='7x' flip="horizontal" />;
     }
   }
 
@@ -47,27 +35,34 @@ export default class ResultPage extends React.PureComponent<Props> {
     const { yourPlay, theirPlay, message, playAgain, abandonGame } = this.props;
 
     return (
-      <div className='container centered-container'>
-        <div className='w-100 text-center mb-5'>
-          <h1 className='mb-5'>{this.renderResultText()}</h1>
-          <div className='row'>
-            <div className='col-sm-6'>
-              <p className='lead'>You chose <strong>{Play[yourPlay]}</strong></p>
-              <div className='mb-5'>
-                {this.renderMoveIcon(yourPlay)}
+      <div className="container centered-container">
+        <div className="w-100 text-center mb-5">
+          <h1 className="mb-5">{this.renderResultText()}</h1>
+          <div className="row">
+            <div className="col-sm-6">
+              <p className="lead">
+                You chose <strong>{Play[yourPlay]}</strong>
+              </p>
+              <div className="mb-5">
+                <MoveIcon play={yourPlay} />
               </div>
             </div>
-            <div className='col-sm-6'>
-              <p className='lead'>Your opponent chose <strong>{Play[theirPlay]}</strong></p>
-              <div className='mb-5'>
-                {this.renderMoveIcon(theirPlay)}
+            <div className="col-sm-6">
+              <p className="lead">
+                Your opponent chose <strong>{Play[theirPlay]}</strong>
+              </p>
+              <div className="mb-5">
+                <MoveIcon play={theirPlay} />
               </div>
             </div>
           </div>
 
-
-          <Button color='default' onClick={abandonGame}>Abandon game</Button>
-          <Button color='primary' onClick={playAgain}>Play again</Button>
+          <Button color="default" onClick={abandonGame}>
+            Abandon game
+          </Button>
+          <Button color="primary" onClick={playAgain}>
+            Play again
+          </Button>
         </div>
 
         <FooterBar>{message}</FooterBar>

--- a/src/components/SelectChallenge.tsx
+++ b/src/components/SelectChallenge.tsx
@@ -8,8 +8,8 @@ import web3Utils from 'web3-utils';
 import { AUTO_OPPONENT_ADDRESS } from '../constants';
 
 interface Props {
-  challenges: Challenge[],
-  acceptChallenge: (address: string, stake: BN) => void,
+  challenges: Challenge[];
+  acceptChallenge: (address: string, stake: BN) => void;
 }
 
 export default class SelectChallenge extends React.PureComponent<Props> {
@@ -18,10 +18,7 @@ export default class SelectChallenge extends React.PureComponent<Props> {
   }
 
   render() {
-    const {
-      challenges,
-      acceptChallenge,
-    } = this.props;
+    const { challenges, acceptChallenge } = this.props;
     return (
       <React.Fragment>
         <Table hover={true}>
@@ -32,12 +29,20 @@ export default class SelectChallenge extends React.PureComponent<Props> {
             </tr>
           </thead>
           <tbody>
-            <tr key={AUTO_OPPONENT_ADDRESS} onClick={() => acceptChallenge(AUTO_OPPONENT_ADDRESS, new BN(web3Utils.toWei("30", 'finney')))} >
+            <tr
+              key={AUTO_OPPONENT_ADDRESS}
+              onClick={() =>
+                acceptChallenge(AUTO_OPPONENT_ADDRESS, new BN(web3Utils.toWei('30', 'finney')))
+              }
+            >
               <td>RockBot 🤖 </td>
               <td>30</td>
             </tr>
             {challenges.map(challenge => (
-              <tr key={challenge.address} onClick={() => acceptChallenge(challenge.address, challenge.stake)} >
+              <tr
+                key={challenge.address}
+                onClick={() => acceptChallenge(challenge.address, challenge.stake)}
+              >
                 <td>{challenge.name}</td>
                 <td>{web3Utils.fromWei(challenge.stake.toString(), 'finney')}</td>
               </tr>

--- a/src/components/SelectPlayPage.tsx
+++ b/src/components/SelectPlayPage.tsx
@@ -1,10 +1,9 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 
 import { Play } from '../game-engine/positions';
 
 import { Button } from 'reactstrap';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faHandRock, faHandPaper, faHandScissors } from '@fortawesome/free-solid-svg-icons';
+import MoveIcon from './MoveIcon';
 
 interface Props {
   choosePlay: (play: Play) => void;
@@ -13,17 +12,12 @@ interface Props {
 }
 
 export default class SelectPlayStep extends React.PureComponent<Props> {
-  renderChooseButton(
-    choosePlay: (play: Play) => void,
-    play: Play,
-    description: string,
-    icon: ReactNode,
-  ) {
+  renderChooseButton(choosePlay: (play: Play) => void, play: Play, description: string) {
     return (
       <Button onClick={() => choosePlay(play)} color="light" className="w-75 p-3">
-        <div className='mb-3'>
+        <div className="mb-3">
           <h1>{description}</h1>
-          {icon}
+          <MoveIcon play={play} />
         </div>
       </Button>
     );
@@ -34,29 +28,25 @@ export default class SelectPlayStep extends React.PureComponent<Props> {
     const renderChooseButton = this.renderChooseButton;
 
     return (
-      <div className='container centered-container'>
-        <div className='w-100 text-center mb-5'>
-          <h1 className='mb-5'>
+      <div className="container centered-container">
+        <div className="w-100 text-center mb-5">
+          <h1 className="mb-5">
             {afterOpponent
               ? 'Your opponent has chosen a move, now choose yours:'
               : 'Choose your move:'}
           </h1>
           <div className="row w-100">
+            <div className="col-sm-4">{renderChooseButton(choosePlay, Play.Rock, 'Rock')}</div>
+            <div className="col-sm-4">{renderChooseButton(choosePlay, Play.Paper, 'Paper')}</div>
             <div className="col-sm-4">
-              {renderChooseButton(choosePlay, Play.Rock, 'Rock', <FontAwesomeIcon icon={faHandRock} size='7x' rotation={90} />)}
-            </div>
-            <div className="col-sm-4">
-              {renderChooseButton(choosePlay, Play.Paper, 'Paper', <FontAwesomeIcon icon={faHandPaper} size='7x' rotation={90} />)}
-            </div>
-            <div className="col-sm-4">
-              {renderChooseButton(choosePlay, Play.Scissors, 'Scissors', <FontAwesomeIcon icon={faHandScissors} size='7x' flip="horizontal" />)}
+              {renderChooseButton(choosePlay, Play.Scissors, 'Scissors')}
             </div>
           </div>
-          <Button onClick={() => abandonGame()} color="dark" className="w-75 p-3">
-            <div className='mb-3'>
+          <div className="mt-5">
+            <Button onClick={() => abandonGame()} color="dark" className="w-75 p-3">
               <h1>Abandon game</h1>
-            </div>
-          </Button>
+            </Button>
+          </div>
         </div>
       </div>
     );

--- a/src/components/WaitingRoomPage.tsx
+++ b/src/components/WaitingRoomPage.tsx
@@ -13,16 +13,19 @@ interface Props {
 
 export default class WaitingRoomPage extends React.PureComponent<Props> {
   render() {
-
     const { cancelChallenge, myChallenge } = this.props;
     return (
-      <div className='container centered-container'>
-        <h2 className='w-100'>Waiting for someone to accept your challenge for {web3Utils.fromWei(myChallenge.stake.toString(), 'finney')} finney</h2>
+      <div className="container centered-container">
+        <h2 className="w-100">
+          Waiting for someone to accept your challenge for{' '}
+          {web3Utils.fromWei(myChallenge.stake.toString(), 'finney')} finney
+        </h2>
 
-        <Button block={true} onClick={cancelChallenge}>Cancel</Button>
+        <Button block={true} onClick={cancelChallenge}>
+          Cancel
+        </Button>
         <FooterBar>Waiting ...</FooterBar>
       </div>
     );
   }
-};
-
+}

--- a/src/components/WaitingStep.tsx
+++ b/src/components/WaitingStep.tsx
@@ -9,13 +9,12 @@ export default class WaitingStep extends React.PureComponent<Props> {
     const { message } = this.props;
 
     return (
-      <div className='container centered-container'>
-      <div className='w-100 text-center mb-5'>
-        <h1 className='mb-5'>Waiting ...</h1>
-        <p className='lead'>{message}</p>
+      <div className="container centered-container">
+        <div className="w-100 text-center mb-5">
+          <h1 className="mb-5">Waiting ...</h1>
+          <p className="lead">{message}</p>
+        </div>
       </div>
-    </div>
     );
   }
 }
-

--- a/src/containers/ApplicationContainer.tsx
+++ b/src/containers/ApplicationContainer.tsx
@@ -22,7 +22,6 @@ function Application(props: ApplicationProps) {
   }
 }
 
-
 const mapStateToProps = (state: SiteState): ApplicationProps => ({
   currentRoom: state.app.currentRoom,
 });

--- a/src/containers/GameContainer.tsx
+++ b/src/containers/GameContainer.tsx
@@ -21,7 +21,7 @@ import { State as GameState } from '../game-engine/application-states';
 import { Play } from '../game-engine/positions';
 
 interface GameProps {
-  state: GameState,
+  state: GameState;
   choosePlay: (play: Play) => void;
   abandonGame: () => void;
   playAgain: () => void;
@@ -71,16 +71,14 @@ function GameContainer(props: GameProps) {
       );
 
     case playerA.WAIT_FOR_CONCLUDE:
-      return (
-        <WaitingStep message="Waiting for opponent to conclude the game" />
-      );
+      return <WaitingStep message="Waiting for opponent to conclude the game" />;
 
     case playerA.CONCLUDED:
       // TODO: add withdraw button!
-      const message = `The game has concluded -- you may now withdraw your winnings of ${state.balances[state.playerIndex]} Finney! [Withdrawal not implemented]`
-      return (
-        <WaitingStep message={message} />
-      );
+      const message = `The game has concluded -- you may now withdraw your winnings of ${
+        state.balances[state.playerIndex]
+      } Finney! [Withdrawal not implemented]`;
+      return <WaitingStep message={message} />;
 
     case playerB.WAIT_FOR_FUNDING:
       return <WalletController />;
@@ -103,16 +101,16 @@ function GameContainer(props: GameProps) {
       );
 
     case playerB.VIEW_RESULT:
-        return (
-          <ResultPage
-            message="Waiting for opponent to suggest a new game"
-            yourPlay={state.bPlay}
-            theirPlay={state.aPlay}
-            result={state.result}
-            playAgain={playAgain}
-            abandonGame={abandonGame}
-          />
-        );
+      return (
+        <ResultPage
+          message="Waiting for opponent to suggest a new game"
+          yourPlay={state.bPlay}
+          theirPlay={state.aPlay}
+          result={state.result}
+          playAgain={playAgain}
+          abandonGame={abandonGame}
+        />
+      );
 
     default:
       return <WaitingStep message={`[view not implemented: ${state.type}`} />;

--- a/src/containers/HomePageContainer.ts
+++ b/src/containers/HomePageContainer.ts
@@ -3,8 +3,7 @@ import { connect } from 'react-redux';
 import HomePage from '../components/HomePage';
 import * as loginActions from '../redux/login/actions';
 
-const mapStateToProps = (state) => ({
-});
+const mapStateToProps = state => ({});
 
 const mapDispatchToProps = {
   login: loginActions.loginRequest,
@@ -13,4 +12,4 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(HomePage)
+)(HomePage);

--- a/src/containers/SiteContainer.tsx
+++ b/src/containers/SiteContainer.tsx
@@ -9,7 +9,6 @@ import MetamaskErrorPage from '../components/MetamaskErrorPage';
 import { MetamaskError } from '../redux/metamask/actions';
 import LoadingPage from '../components/LoadingPage';
 
-
 interface SiteProps {
   isAuthenticated: boolean;
   metamaskError: MetamaskError | null;
@@ -18,7 +17,7 @@ interface SiteProps {
 
 function Site(props: SiteProps) {
   if (props.loading) {
-    return <LoadingPage/>;
+    return <LoadingPage />;
   } else if (props.metamaskError !== null) {
     return <MetamaskErrorPage error={props.metamaskError} />;
   } else if (props.isAuthenticated) {
@@ -26,7 +25,7 @@ function Site(props: SiteProps) {
   } else {
     return <HomePageContainer />;
   }
-};
+}
 
 const mapStateToProps = (state: SiteState): SiteProps => {
   return {

--- a/src/wallet/components/ConfirmFunding.tsx
+++ b/src/wallet/components/ConfirmFunding.tsx
@@ -4,7 +4,6 @@ import web3Utils from 'web3-utils';
 import Button from '../../components/Button';
 import { StyleSheet, css } from 'aphrodite';
 
-
 export interface ConfirmFundingProps {
   myBalance: BN;
   opponentBalance: BN;
@@ -41,32 +40,34 @@ export default class ConfirmFunding extends React.Component<
         <p>The initial deposits will be:</p>
         <div>
           <div>
-            You (
-            {myAddress}
+            You ({myAddress}
             ): {web3Utils.fromWei(myBalance, 'finney')} finney
           </div>
           <div>
-            Opponent (
-            {opponentAddress}
+            Opponent ({opponentAddress}
             ): {web3Utils.fromWei(opponentBalance, 'finney')} finney
           </div>
         </div>
         <p>Do you wish to open this channel?</p>
         <div className={css(styles.buttonContainer)}>
-          <span className={css(styles.button)}><Button onClick={decline}>No</Button></span>
-          <span className={css(styles.button)}><Button onClick={approve}>Yes</Button></span>
+          <span className={css(styles.button)}>
+            <Button onClick={decline}>No</Button>
+          </span>
+          <span className={css(styles.button)}>
+            <Button onClick={approve}>Yes</Button>
+          </span>
         </div>
       </div>
     );
   }
 }
 const styles = StyleSheet.create({
-    buttonContainer: {
-      display: 'flex',
-      justifyContent:'center',
-      padding:"5px",
-    },
-    button:{
-        margin:"15px",
-    },
+  buttonContainer: {
+    display: 'flex',
+    justifyContent: 'center',
+    padding: '5px',
+  },
+  button: {
+    margin: '15px',
+  },
 });

--- a/src/wallet/components/FundingError.tsx
+++ b/src/wallet/components/FundingError.tsx
@@ -8,9 +8,11 @@ interface Props {
 
 export default class FundingError extends React.PureComponent<Props> {
   render() {
-    return <div>
-    <div>{this.props.message}</div>
-    <Button onClick={this.props.tryAgain}>Try Again</Button>
-    </div>;
+    return (
+      <div>
+        <div>{this.props.message}</div>
+        <Button onClick={this.props.tryAgain}>Try Again</Button>
+      </div>
+    );
   }
 }

--- a/src/wallet/components/WalletController.tsx
+++ b/src/wallet/components/WalletController.tsx
@@ -47,7 +47,12 @@ export default class WalletController extends PureComponent<Props> {
         return <FundingInProgress message="waiting for deposit confirmation" />;
       case WaitForApproval:
       case playerB.WaitForApprovalWithAdjudicator:
-        const { myAddress, opponentAddress, myBalance, opponentBalance } = walletState as WaitForApproval;
+        const {
+          myAddress,
+          opponentAddress,
+          myBalance,
+          opponentBalance,
+        } = walletState as WaitForApproval;
         const confirmFundingProps = {
           myAddress,
           opponentAddress,


### PR DESCRIPTION
Drys up the icon logic and repositions the icon. Fixes some spacing in the flow.

I also ran prettier (which everyone should set up in their editor!!!) in the components folder, which cleaned up the code nicely.

#### Centered icon on "you chose" screen
![screen shot 2018-09-13 at 8 09 27 pm](https://user-images.githubusercontent.com/12832034/45527628-7ff98500-b791-11e8-8a49-b3d733de2b41.png)

#### Centered icon on "You won"/"You lost" screen
![screen shot 2018-09-13 at 8 09 34 pm](https://user-images.githubusercontent.com/12832034/45527629-7ff98500-b791-11e8-92b2-939b0b6cda9e.png)

#### Updated spacing on play selection screen
![screen shot 2018-09-13 at 8 08 33 pm](https://user-images.githubusercontent.com/12832034/45527780-42e1c280-b792-11e8-8a09-b0b0a61ffa53.png)

