### PR TITLE
Refactor setup sagas

### DIFF
--- a/src/wallet/redux/actions/external.ts
+++ b/src/wallet/redux/actions/external.ts
@@ -121,10 +121,16 @@ export type WithdrawalResponse = FundingSuccess | FundingFailure;
 // ==============
 
 export const INITIALIZATION_SUCCESS = 'WALLET.INITIALIZATION.SUCCESS';
+export const INITIALIZATION_FAILURE = 'WALLET.INITIALIZATION.FAILURE';
 
 export const initializationSuccess = address => ({
   type: INITIALIZATION_SUCCESS as typeof INITIALIZATION_SUCCESS,
   address,
+});
+
+export const initializationFailure = (message: string) => ({
+  type: INITIALIZATION_FAILURE as typeof INITIALIZATION_FAILURE,
+  message,
 });
 
 export type InitializationSuccess = ReturnType<typeof initializationSuccess>;

--- a/src/wallet/redux/sagas/blockchain.ts
+++ b/src/wallet/redux/sagas/blockchain.ts
@@ -37,14 +37,14 @@ export function* blockchainSaga() {
     blockchainActions.DEPOSIT_REQUEST,
   ]);
 
+  const network = yield call(detectNetwork, web3.currentProvider);
+  const simpleAdjudicatorContract = contract(simpleAdjudicatorArtifact);
+  yield call(simpleAdjudicatorContract.defaults, { from: web3.eth.defaultAccount });
+  simpleAdjudicatorContract.setProvider(web3.currentProvider);
+  simpleAdjudicatorContract.setNetwork(network.id);
+
   while (true) {
     const action = yield take(channel);
-
-    const network = yield call(detectNetwork, web3.currentProvider);
-    const simpleAdjudicatorContract = contract(simpleAdjudicatorArtifact);
-    yield call(simpleAdjudicatorContract.defaults, { from: web3.eth.defaultAccount });
-    simpleAdjudicatorContract.setProvider(web3.currentProvider);
-    simpleAdjudicatorContract.setNetwork(network.id);
 
     switch (action.type) {
       case blockchainActions.DEPLOY_REQUEST:
@@ -69,11 +69,11 @@ export function* blockchainSaga() {
           const existingContract = yield call(simpleAdjudicatorContract.at, action.address);
           const transaction = yield call(existingContract.send, action.amount.toString());
           yield put(blockchainActions.depositSuccess(transaction));
-          break;
         } catch (err) {
           const message = err.message ? err.message : "Something went wrong";
           yield put(blockchainActions.depositFailure(message));
         }
+        break;
     }
   }
 }

--- a/src/wallet/redux/sagas/wallet.ts
+++ b/src/wallet/redux/sagas/wallet.ts
@@ -1,4 +1,4 @@
-import { actionChannel, take, put, fork } from 'redux-saga/effects';
+import { actionChannel, take, put, fork, } from 'redux-saga/effects';
 
 import { initializeWallet } from './initialization';
 import * as actions from '../actions/external';
@@ -9,6 +9,7 @@ import { AUTO_OPPONENT_ADDRESS } from '../../../constants';
 
 export function* walletSaga(uid: string): IterableIterator<any> {
   const wallet = yield initializeWallet(uid);
+  yield fork(blockchainSaga);
 
   const channel = yield actionChannel([
     actions.FUNDING_REQUEST,
@@ -19,7 +20,7 @@ export function* walletSaga(uid: string): IterableIterator<any> {
   yield put(actions.initializationSuccess(wallet.address));
 
   while(true) {
-    const action: actions.RequestAction = yield take(channel);
+    const action: actions.RequestAction = yield take(channel)
 
     // The handlers below will block, so the wallet will only ever
     // process one action at a time from the queue.
@@ -71,7 +72,6 @@ function* handleFundingRequest(_wallet: ChannelWallet, channelId, state) {
   if (state.opponentAddress === AUTO_OPPONENT_ADDRESS) {
     success = true
   } else {
-    yield fork(blockchainSaga);
     success = yield fundingSaga(channelId, state);
   }
 
@@ -80,5 +80,5 @@ function* handleFundingRequest(_wallet: ChannelWallet, channelId, state) {
   } else {
     yield put(actions.fundingFailure(channelId, 'Something went wrong'));
   }
+  return true;
 }
-


### PR DESCRIPTION
Considering the pattern of delegating to a sub-saga, we want to spawn
instead of fork. If we fork a child inside a subsaga, the subsaga doesn't
complete until its children do.

If we spawn instead, then we can `call` a subsaga, rather than using
yield*, as recommended by the docs:
https://redux-saga.js.org/docs/advanced/ComposingSagas.html

In addition, we expect a `setupBlah` sub-saga to complete before moving
on, but as in this case, a part of that setup might be to kick off
a long running saga.