### PR TITLE
Sign and validate states when they are sent as messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lodash": "^4.17.10",
     "nanoid": "^1.0.3",
     "object-assign": "4.1.1",
+    "object-hash": "^1.3.0",
     "promise": "8.0.1",
     "prop-types": "^15.6.2",
     "raf": "3.4.0",

--- a/src/game-engine/positions/decode.test.ts
+++ b/src/game-engine/positions/decode.test.ts
@@ -1,4 +1,4 @@
-import { Channel } from 'fmg-core';
+import { Channel, State } from 'fmg-core';
 
 import { hashCommitment, Play } from '.';
 import decode from './decode';
@@ -33,7 +33,8 @@ const preCommit = hashCommitment(aPlay, salt);
 const testEncodeDecode = (pledge) => {
   it(`${pledge.constructor.name} is the same after encoding and decoding`, () => {
     const encoded = pledge.toHex();
-    const decoded = decode(encoded);
+    const state = pledge as State;
+    const decoded = decode(state,encoded);
     // We need to use JSON stringify due to the BN.js having possible different 
     // internal representations of the same number
     expect(JSON.stringify(decoded)).toEqual(JSON.stringify(pledge));

--- a/src/game-engine/positions/decode.test.ts
+++ b/src/game-engine/positions/decode.test.ts
@@ -1,4 +1,4 @@
-import { Channel, State } from 'fmg-core';
+import { Channel } from 'fmg-core';
 
 import { hashCommitment, Play } from '.';
 import decode from './decode';
@@ -33,8 +33,7 @@ const preCommit = hashCommitment(aPlay, salt);
 const testEncodeDecode = (pledge) => {
   it(`${pledge.constructor.name} is the same after encoding and decoding`, () => {
     const encoded = pledge.toHex();
-    const state = pledge as State;
-    const decoded = decode(state,encoded);
+    const decoded = decode(encoded);
     // We need to use JSON stringify due to the BN.js having possible different 
     // internal representations of the same number
     expect(JSON.stringify(decoded)).toEqual(JSON.stringify(pledge));

--- a/src/game-engine/positions/decode.ts
+++ b/src/game-engine/positions/decode.ts
@@ -11,6 +11,7 @@ import Reveal from './Reveal';
 import Resting from './Resting';
 import Conclude from './Conclude';
 import BN from 'bn.js';
+import decodeState from '../../wallet/domain/decode';
 
 const PREFIX_CHARS = 2; // the 0x takes up 2 characters
 const CHARS_PER_BYTE = 2;
@@ -67,7 +68,9 @@ function extractSalt(hexString: string) {
   return extractBytes(hexString, GAME_ATTRIBUTE_OFFSET + 5 * 32);
 }
 
-export default function decode(state: State, hexString: string) {
+export default function decode(hexString: string) {
+
+  const state = decodeState(hexString);
   const channel = state.channel;
   const turnNum = state.turnNum;
   const stateType = state.stateType;

--- a/src/game-engine/positions/decode.ts
+++ b/src/game-engine/positions/decode.ts
@@ -1,4 +1,4 @@
-import { Channel, State } from 'fmg-core';
+import { State } from 'fmg-core';
 
 import { Play, GamePositionType } from '.';
 import PreFundSetupA from './PreFundSetupA';
@@ -19,8 +19,8 @@ const CHANNEL_BYTES = 32 + 32 + 32 + 32 * N_PLAYERS; // type, nonce, nPlayers, [
 const STATE_BYTES = 32 + 32 + 32 + 32 * N_PLAYERS; // stateType, turnNum, stateCount, [balances]
 const GAME_ATTRIBUTE_OFFSET = CHANNEL_BYTES + STATE_BYTES;
 
-function extractBN(hexString: string, byteOffset: number = 0, numBytes: number = 32){
-  return new BN(extractBytes(hexString, byteOffset, numBytes).substr(2),16);
+function extractBN(hexString: string, byteOffset: number = 0, numBytes: number = 32) {
+  return new BN(extractBytes(hexString, byteOffset, numBytes).substr(2), 16);
 }
 function extractInt(hexString: string, byteOffset: number = 0, numBytes: number = 32) {
   return parseInt(extractBytes(hexString, byteOffset, numBytes), 16);
@@ -31,39 +31,6 @@ function extractBytes(hexString: string, byteOffset: number = 0, numBytes: numbe
   return '0x' + hexString.substr(charOffset, numBytes * CHARS_PER_BYTE);
 }
 
-function extractChannel(hexString: string) {
-  const channelType = extractBytes(hexString, 12, 20);
-  const channelNonce = extractInt(hexString, 32);
-  const nPlayers = extractInt(hexString, 64);
-  if (nPlayers !== N_PLAYERS) {
-    throw new Error(
-      `Rock-paper-scissors requires exactly ${N_PLAYERS} players. ${nPlayers} provided.`,
-    );
-  }
-
-  const participantA = extractBytes(hexString, 3 * 32 + 12, 20);
-  const participantB = extractBytes(hexString, 4 * 32 + 12, 20);
-
-  return new Channel(channelType, channelNonce, [participantA, participantB]);
-}
-
-function extractStateType(hexString: string) {
-  return extractInt(hexString, CHANNEL_BYTES);
-}
-
-function extractTurnNum(hexString: string) {
-  return extractInt(hexString, CHANNEL_BYTES + 32);
-}
-
-function extractStateCount(hexString: string) {
-  return extractInt(hexString, CHANNEL_BYTES + 64);
-}
-
-function extractBalances(hexString: string) {
-  const aBal = extractBN(hexString, CHANNEL_BYTES + 3 * 32);
-  const bBal = extractBN(hexString, CHANNEL_BYTES + 4 * 32);
-  return [aBal, bBal];
-}
 
 // RockPaperScissors State Fields
 // (relative to gamestate offset)
@@ -100,7 +67,39 @@ function extractSalt(hexString: string) {
   return extractBytes(hexString, GAME_ATTRIBUTE_OFFSET + 5 * 32);
 }
 
-function decodeGameState(channel, turnNum: number, balances: BN[], hexString: string) {
+export default function decode(state: State, hexString: string) {
+  const channel = state.channel;
+  const turnNum = state.turnNum;
+  const stateType = state.stateType;
+  const balances = state.resolution;
+
+  switch (stateType) {
+    case State.StateType.Conclude:
+      return new Conclude(channel, turnNum, balances);
+    case State.StateType.PreFundSetup:
+      const stateCountPre = state.stateCount;
+      const stakePre = extractStake(hexString);
+      if (stateCountPre === 0) {
+        return new PreFundSetupA(channel, turnNum, balances, stateCountPre, stakePre);
+      } else {
+        return new PreFundSetupB(channel, turnNum, balances, stateCountPre, stakePre);
+      }
+    case State.StateType.PostFundSetup:
+      const stateCountPost = state.stateCount;
+      const stakePost = extractStake(hexString);
+      if (stateCountPost === 0) {
+        return new PostFundSetupA(channel, turnNum, balances, stateCountPost, stakePost);
+      } else {
+        return new PostFundSetupB(channel, turnNum, balances, stateCountPost, stakePost);
+      }
+    case State.StateType.Game:
+      return decodeGameState(channel, turnNum, balances, hexString);
+    default:
+      throw new Error('unreachable');
+  }
+}
+
+export function decodeGameState(channel, turnNum: number, balances: BN[], hexString: string) {
   const position = extractGamePositionType(hexString);
   const stake = extractStake(hexString);
 
@@ -122,34 +121,3 @@ function decodeGameState(channel, turnNum: number, balances: BN[], hexString: st
   }
 }
 
-export default function decode(hexString) {
-  const channel = extractChannel(hexString);
-  const turnNum = extractTurnNum(hexString);
-  const stateType = extractStateType(hexString);
-  const balances = extractBalances(hexString);
-
-  switch (stateType) {
-    case State.StateType.Conclude:
-      return new Conclude(channel, turnNum, balances);
-    case State.StateType.PreFundSetup:
-      const stateCountPre = extractStateCount(hexString);
-      const stakePre = extractStake(hexString);
-      if (stateCountPre === 0) {
-        return new PreFundSetupA(channel, turnNum, balances, stateCountPre, stakePre);
-      } else {
-        return new PreFundSetupB(channel, turnNum, balances, stateCountPre, stakePre);
-      }
-    case State.StateType.PostFundSetup:
-      const stateCountPost = extractStateCount(hexString);
-      const stakePost = extractStake(hexString);
-      if (stateCountPost === 0) {
-        return new PostFundSetupA(channel, turnNum, balances, stateCountPost, stakePost);
-      } else {
-        return new PostFundSetupB(channel, turnNum, balances, stateCountPost, stakePost);
-      }
-    case State.StateType.Game:
-      return decodeGameState(channel, turnNum, balances, hexString);
-    default:
-      throw new Error('unreachable');
-  }
-}

--- a/src/redux/auto-opponent/saga.ts
+++ b/src/redux/auto-opponent/saga.ts
@@ -9,7 +9,6 @@ import { Play } from '../../game-engine/positions';
 import { default as positionFromHex } from '../../game-engine/positions/decode';
 import ChannelWallet from '../../wallet/domain/ChannelWallet';
 import { AUTO_OPPONENT_PRIVATE_KEY } from '../../constants';
-import * as walletActions from '../../wallet/redux/actions/external';
 
 export default function* autoOpponentSaga() {
   const wallet = new ChannelWallet(AUTO_OPPONENT_PRIVATE_KEY); // generate new wallet just for this process
@@ -23,13 +22,11 @@ export default function* autoOpponentSaga() {
     const action: autoOpponentActions.MessageFromApp = yield take(channel);
 
     yield delay(2000);
-    yield put(walletActions.decodeStateRequest(action.data));
-    const decodeAction: walletActions.DecodeStateSuccess = yield take(walletActions.DECODE_STATE_SUCCESS);
     if (gameEngine === null) {
       // Start up the game engine for our autoplayer B
-      gameEngine = fromProposal(positionFromHex(decodeAction.state, action.data));
+      gameEngine = fromProposal(positionFromHex(action.data));
     } else {
-      gameEngine.receivePosition(positionFromHex(decodeAction.state, action.data));
+      gameEngine.receivePosition(positionFromHex(action.data));
     }
 
     let state = gameEngine.state;

--- a/src/redux/game/saga.ts
+++ b/src/redux/game/saga.ts
@@ -32,9 +32,7 @@ export default function* gameSaga(gameEngine: GameEngine) {
 
     switch (action.type) {
       case messageActions.MESSAGE_RECEIVED:
-        yield put(walletActions.decodeStateRequest(action.message));
-        const decodeAction: walletActions.DecodeStateSuccess = yield take(walletActions.DECODE_STATE_SUCCESS);
-        newState = gameEngine.receivePosition(positionFromHex(decodeAction.state,action.message));
+        newState = gameEngine.receivePosition(positionFromHex(action.message));
         break;
       case gameActions.CHOOSE_PLAY:
         newState = gameEngine.choosePlay(action.play);

--- a/src/redux/game/saga.ts
+++ b/src/redux/game/saga.ts
@@ -32,7 +32,9 @@ export default function* gameSaga(gameEngine: GameEngine) {
 
     switch (action.type) {
       case messageActions.MESSAGE_RECEIVED:
-        newState = gameEngine.receivePosition(positionFromHex(action.message));
+        yield put(walletActions.decodeStateRequest(action.message));
+        const decodeAction: walletActions.DecodeStateSuccess = yield take(walletActions.DECODE_STATE_SUCCESS);
+        newState = gameEngine.receivePosition(positionFromHex(decodeAction.state,action.message));
         break;
       case gameActions.CHOOSE_PLAY:
         newState = gameEngine.choosePlay(action.play);

--- a/src/redux/message-service/saga.ts
+++ b/src/redux/message-service/saga.ts
@@ -61,6 +61,9 @@ function* receiveFromFirebaseSaga(address: string) {
     const { data, queue } = message.value;
 
     if (queue === Queue.GAME_ENGINE) {
+      const { signaure } = message.value;
+      const requestId = hash(message + Date.now());
+      yield put(walletActions.validationRequest(requestId, data,signaure));
       yield put(messageActions.messageReceived(data));
     } else {
       yield put(walletActions.receiveMessage(data));

--- a/src/redux/message-service/saga.ts
+++ b/src/redux/message-service/saga.ts
@@ -6,34 +6,42 @@ import * as messageActions from './actions';
 import * as autoOpponentActions from '../auto-opponent/actions';
 import { actions as walletActions } from '../../wallet';
 import { AUTO_OPPONENT_ADDRESS } from '../../constants';
-
+import { SignatureSuccess } from '../../wallet/redux/actions/external';
+import hash from 'object-hash';
 export enum Queue {
   WALLET = 'WALLET',
   GAME_ENGINE = 'GAME_ENGINE',
 }
 
 function* sendMessagesSaga() {
-  const channel = yield actionChannel([
-    messageActions.SEND_MESSAGE,
-    walletActions.SEND_MESSAGE,
-  ]);
+  const channel = yield actionChannel([messageActions.SEND_MESSAGE, walletActions.SEND_MESSAGE]);
 
   while (true) {
-    const action: messageActions.SendMessage | walletActions.SendMessage = yield take(channel); 
+    const action: messageActions.SendMessage | walletActions.SendMessage = yield take(channel);
 
     const { to, data } = action;
-
+    let message = {};
     let queue;
     if (action.type === messageActions.SEND_MESSAGE) {
+      const requestId = hash(`${data}${Date.now()}`);
+
+      yield put(walletActions.signatureRequest(requestId, data));
+      // TODO: Handle signature failure
+      let signatureCompleteAction: SignatureSuccess = yield take(walletActions.SIGNATURE_SUCCESS);
+      while (signatureCompleteAction.requestId !== requestId) {
+        signatureCompleteAction = yield take(walletActions.SIGNATURE_SUCCESS);
+      }
       queue = Queue.GAME_ENGINE;
+      message = { data, queue, signature: signatureCompleteAction.signature };
     } else {
       queue = Queue.WALLET;
+      message = { data, queue };
     }
 
     if (to === AUTO_OPPONENT_ADDRESS) {
-      yield put(autoOpponentActions.messageFromApp(data))
+      yield put(autoOpponentActions.messageFromApp(data));
     } else {
-      yield call(reduxSagaFirebase.database.create, `/messages/${to}`, { data, queue });
+      yield call(reduxSagaFirebase.database.create, `/messages/${to}`, message);
     }
   }
 }
@@ -46,7 +54,7 @@ function* receiveFromFirebaseSaga(address: string) {
     buffers.fixed(10),
   );
 
-  while(true) {
+  while (true) {
     const message = yield take(channel);
     const key = message.snapshot.key;
 
@@ -64,7 +72,7 @@ function* receiveFromFirebaseSaga(address: string) {
 function* receiveFromAutoOpponentSaga() {
   const channel = yield actionChannel(autoOpponentActions.MESSAGE_TO_APP);
 
-  while(true) {
+  while (true) {
     const action: autoOpponentActions.MessageToApp = yield take(channel);
     yield put(messageActions.messageReceived(action.data));
   }

--- a/src/redux/message-service/saga.ts
+++ b/src/redux/message-service/saga.ts
@@ -91,7 +91,7 @@ function* validateMessage(data, signature) {
 }
 
 function* signMessage(data) {
-  const requestId = hash(`${data}${Date.now()}`);
+  const requestId = hash(data+Date.now());
 
   yield put(walletActions.signatureRequest(requestId, data));
   // TODO: Handle signature failure

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -15,6 +15,6 @@ sagaMiddleware.run(loginSaga);
 
 export default store;
 
-export const getApplicationState = (storeObj: any) => storeObj.game;
+export const getApplicationState = (storeObj: any) => storeObj.app;
 export const getWalletState = (storeObj: any) => storeObj.wallet;
 export const getUser = (storeObj: any) => storeObj.login.user;

--- a/src/redux/waiting-room/saga.ts
+++ b/src/redux/waiting-room/saga.ts
@@ -6,7 +6,6 @@ import * as messageActions from '../message-service/actions';
 import * as applicationActions from '../application/actions';
 import GameEngineB from '../../game-engine/GameEngineB';
 import decode from '../../game-engine/positions/decode';
-import * as walletActions from '../../wallet/redux/actions/external';
 import { delay } from 'redux-saga';
 import BN from 'bn.js';
 import { CHALLENGE_REFRESH_INTERVAL } from '../../constants';
@@ -55,9 +54,7 @@ export default function* waitingRoomSaga(
         break;
 
       case messageActions.MESSAGE_RECEIVED:
-        yield put(walletActions.decodeStateRequest(action.message));
-        const decodeAction = yield take(walletActions.DECODE_STATE_SUCCESS);
-        const position = decode(decodeAction.state, action.message);
+        const position = decode(action.message);
         const gameEngine = GameEngineB.fromProposal(position);
         // todo: handle error if it isn't a propose state with the right properties
         yield call(reduxSagaFirebase.database.delete, `/challenges/${address}`);

--- a/src/wallet/domain/ChannelWallet.ts
+++ b/src/wallet/domain/ChannelWallet.ts
@@ -25,4 +25,9 @@ import Web3 from 'web3';
     return this.account.sign(stateString).signature;
     
   }
+  
+  recover(data:string, signature:string){
+    const web3 = new Web3('');
+    return web3.eth.accounts.recover(data,signature);
+  }
 }

--- a/src/wallet/domain/ChannelWallet.ts
+++ b/src/wallet/domain/ChannelWallet.ts
@@ -1,9 +1,7 @@
 import Web3 from 'web3';
 
-
- export default class ChannelWallet {
+export default class ChannelWallet {
   account: any; // todo: figure out how to do types with web3
-
   constructor(privateKey?: string) {
     const web3 = new Web3('');
     if (privateKey) {
@@ -21,13 +19,13 @@ import Web3 from 'web3';
     return this.account.privateKey;
   }
 
-  sign(stateString: string):string  {
+  sign(stateString: string): string {
     return this.account.sign(stateString).signature;
-    
+
   }
-  
-  recover(data:string, signature:string){
+
+  recover(data: string, signature: string) {
     const web3 = new Web3('');
-    return web3.eth.accounts.recover(data,signature);
+    return web3.eth.accounts.recover(data, signature);
   }
 }

--- a/src/wallet/domain/__tests__/decode.test.ts
+++ b/src/wallet/domain/__tests__/decode.test.ts
@@ -1,0 +1,35 @@
+import { Channel, State } from 'fmg-core';
+
+import decode from '../decode';
+import BN from 'bn.js';
+
+const gameLibrary = '0x0000000000000000000000000000000000000111';
+const channelNonce = 15;
+const participantA = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const participantB = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const participants = [participantA, participantB];
+const channel = new Channel(gameLibrary, channelNonce, participants);
+const stateCount = 0;
+const turnNum = 5;
+const aBal = new BN(4);
+const bBal = new BN(5);
+const balances = [aBal, bBal];
+
+
+const testEncodeDecode = (pledge) => {
+  it(`${pledge.constructor.name} is the same after encoding and decoding`, () => {
+    const encoded = pledge.toHex();
+    const decoded = decode(encoded);
+    // We need to use JSON stringify due to the BN.js having possible different 
+    // internal representations of the same number
+    expect(JSON.stringify(decoded)).toEqual(JSON.stringify(pledge));
+  });
+};
+
+describe('decode', () => {
+  testEncodeDecode(new State({channel, turnNum, resolution:balances, stateCount,stateType: State.StateType.Conclude}));
+  testEncodeDecode(new State({channel, turnNum, resolution:balances, stateCount,stateType: State.StateType.Game}));
+  testEncodeDecode(new State({channel, turnNum, resolution:balances, stateCount,stateType: State.StateType.PostFundSetup}));
+  testEncodeDecode(new State({channel, turnNum, resolution:balances, stateCount,stateType: State.StateType.PreFundSetup}));
+
+});

--- a/src/wallet/domain/decode.ts
+++ b/src/wallet/domain/decode.ts
@@ -1,0 +1,68 @@
+import { Channel, State, } from 'fmg-core';
+
+import BN from 'bn.js';
+
+const PREFIX_CHARS = 2; // the 0x takes up 2 characters
+const CHARS_PER_BYTE = 2;
+const N_PLAYERS = 2;
+const CHANNEL_BYTES = 32 + 32 + 32 + 32 * N_PLAYERS; // type, nonce, nPlayers, [players]
+const STATE_BYTES = 32 + 32 + 32 + 32 * N_PLAYERS; // stateType, turnNum, stateCount, [balances]
+export const GAME_ATTRIBUTE_OFFSET = CHANNEL_BYTES + STATE_BYTES;
+
+function extractBN(hexString: string, byteOffset: number = 0, numBytes: number = 32) {
+  return new BN(extractBytes(hexString, byteOffset, numBytes).substr(2), 16);
+}
+function extractInt(hexString: string, byteOffset: number = 0, numBytes: number = 32) {
+  return parseInt(extractBytes(hexString, byteOffset, numBytes), 16);
+}
+
+function extractBytes(hexString: string, byteOffset: number = 0, numBytes: number = 32) {
+  const charOffset = PREFIX_CHARS + byteOffset * CHARS_PER_BYTE;
+  return '0x' + hexString.substr(charOffset, numBytes * CHARS_PER_BYTE);
+}
+
+function extractChannel(hexString: string) {
+  const channelType = extractBytes(hexString, 12, 20);
+  const channelNonce = extractInt(hexString, 32);
+  const nPlayers = extractInt(hexString, 64);
+  if (nPlayers !== N_PLAYERS) {
+    throw new Error(
+      `${N_PLAYERS} players required. ${nPlayers} provided.`,
+    );
+  }
+
+  const participantA = extractBytes(hexString, 3 * 32 + 12, 20);
+  const participantB = extractBytes(hexString, 4 * 32 + 12, 20);
+
+  return new Channel(channelType, channelNonce, [participantA, participantB]);
+}
+
+function extractStateType(hexString: string) {
+  return extractInt(hexString, CHANNEL_BYTES);
+}
+
+function extractTurnNum(hexString: string) {
+  return extractInt(hexString, CHANNEL_BYTES + 32);
+}
+
+function extractStateCount(hexString: string) {
+  return extractInt(hexString, CHANNEL_BYTES + 64);
+}
+
+function extractBalances(hexString: string) {
+  const aBal = extractBN(hexString, CHANNEL_BYTES + 3 * 32);
+  const bBal = extractBN(hexString, CHANNEL_BYTES + 4 * 32);
+  return [aBal, bBal];
+}
+
+
+
+export default function decode(hexString) {
+  const channel = extractChannel(hexString);
+  const turnNum = extractTurnNum(hexString);
+  const stateType = extractStateType(hexString);
+  const balances = extractBalances(hexString);
+  const stateCount = extractStateCount(hexString);
+  return new State({ channel, turnNum, resolution: balances, stateCount, stateType });
+
+}

--- a/src/wallet/domain/decode.ts
+++ b/src/wallet/domain/decode.ts
@@ -1,6 +1,8 @@
 import { Channel, State, } from 'fmg-core';
-
 import BN from 'bn.js';
+
+  // TODO: The decode function should really be part of FMG-Core
+  // Eventually it would be pulled out there
 
 const PREFIX_CHARS = 2; // the 0x takes up 2 characters
 const CHARS_PER_BYTE = 2;

--- a/src/wallet/redux/actions/external.ts
+++ b/src/wallet/redux/actions/external.ts
@@ -167,10 +167,9 @@ export const decodeStateRequest = (data: string) => ({
   data,
 });
 
-export const decodeStateSuccess = (state: State, additionalData?: string) => ({
+export const decodeStateSuccess = (state: State) => ({
   type: DECODE_STATE_SUCCESS as typeof DECODE_STATE_SUCCESS,
   state,
-  additionalData,
 });
 
 export const decodeStateFailure = (message: string) => ({

--- a/src/wallet/redux/actions/external.ts
+++ b/src/wallet/redux/actions/external.ts
@@ -41,15 +41,15 @@ export const VALIDATION_REQUEST = 'WALLET.VALIDATION.REQUEST';
 export const VALIDATION_SUCCESS = 'WALLET.VALIDATION.SUCCESS';
 export const VALIDATION_FAILURE = 'WALLET.VALIDATION.FAILURE';
 
-export const validationRequest = (requestId: string, signedPositionData: string) => ({
+export const validationRequest = (requestId: string, positionData: string, signature:string) => ({
   type: VALIDATION_REQUEST as typeof VALIDATION_REQUEST,
   requestId,
-  signedPositionData,
+  positionData,
+  signature,
 });
-export const validationSuccess = (requestId: string, positionData: string) => ({
+export const validationSuccess = (requestId: string) => ({
   type: VALIDATION_SUCCESS as typeof VALIDATION_SUCCESS,
   requestId,
-  positionData,
 });
 export const validationFailure = (requestId: string, reason: string) => ({
   type: VALIDATION_FAILURE as typeof VALIDATION_FAILURE,

--- a/src/wallet/redux/actions/external.ts
+++ b/src/wallet/redux/actions/external.ts
@@ -6,7 +6,6 @@ import {
   WaitForFunding as WaitForFundingB,
   Concluded as ConcludedB,
 } from '../../../game-engine/application-states/PlayerB';
-import { State } from 'fmg-core';
 
 // FUNDING
 // =======
@@ -158,30 +157,7 @@ export type ReceiveMessage = ReturnType<typeof receiveMessage>;
 
 // DECODING
 // ========
-export const DECODE_STATE_REQUEST = 'WAllET.DECODE.REQUEST';
-export const DECODE_STATE_SUCCESS = 'WAllET.DECODE.SUCCESS';
-export const DECODE_STATE_FAILURE = 'WAllET.DECODE.FAILURE';
-
-export const decodeStateRequest = (data: string) => ({
-  type: DECODE_STATE_REQUEST as typeof DECODE_STATE_REQUEST,
-  data,
-});
-
-export const decodeStateSuccess = (state: State) => ({
-  type: DECODE_STATE_SUCCESS as typeof DECODE_STATE_SUCCESS,
-  state,
-});
-
-export const decodeStateFailure = (message: string) => ({
-  type: DECODE_STATE_FAILURE as typeof DECODE_STATE_FAILURE,
-  message,
-});
-
-export type DecodeStateRequest = ReturnType<typeof decodeStateRequest>;
-export type DecodeStateSuccess = ReturnType<typeof decodeStateSuccess>;
-export type DecodeStateFailure = ReturnType<typeof decodeStateFailure>;
-export type DecodeStateResponse = DecodeStateFailure | DecodeStateSuccess;
 
 // Requests
 // ========
-export type RequestAction = FundingRequest | SignatureRequest | ValidationRequest | WithdrawalRequest | DecodeStateRequest;
+export type RequestAction = FundingRequest | SignatureRequest | ValidationRequest | WithdrawalRequest;

--- a/src/wallet/redux/actions/external.ts
+++ b/src/wallet/redux/actions/external.ts
@@ -41,11 +41,12 @@ export const VALIDATION_REQUEST = 'WALLET.VALIDATION.REQUEST';
 export const VALIDATION_SUCCESS = 'WALLET.VALIDATION.SUCCESS';
 export const VALIDATION_FAILURE = 'WALLET.VALIDATION.FAILURE';
 
-export const validationRequest = (requestId: string, positionData: string, signature:string) => ({
+export const validationRequest = (requestId: string, positionData: string, signature:string, expectedAddress:string) => ({
   type: VALIDATION_REQUEST as typeof VALIDATION_REQUEST,
   requestId,
   positionData,
   signature,
+  expectedAddress,
 });
 export const validationSuccess = (requestId: string) => ({
   type: VALIDATION_SUCCESS as typeof VALIDATION_SUCCESS,

--- a/src/wallet/redux/actions/external.ts
+++ b/src/wallet/redux/actions/external.ts
@@ -74,10 +74,10 @@ export const signatureRequest = (requestId: string, positionData: string) => ({
   requestId,
   positionData,
 });
-export const signatureSuccess = (requestId: string, moveData: string) => ({
+export const signatureSuccess = (requestId: string, signature: string) => ({
   type: SIGNATURE_SUCCESS as typeof SIGNATURE_SUCCESS,
   requestId,
-  moveData,
+  signature,
 });
 export const signatureFailure = (requestId: string, reason: string) => ({
   type: SIGNATURE_FAILURE as typeof SIGNATURE_FAILURE,

--- a/src/wallet/redux/actions/external.ts
+++ b/src/wallet/redux/actions/external.ts
@@ -1,11 +1,12 @@
 import {
-  WaitForFunding as WaitForFundingA, 
-  Concluded as ConcludedA, 
+  WaitForFunding as WaitForFundingA,
+  Concluded as ConcludedA,
 } from '../../../game-engine/application-states/PlayerA';
 import {
-  WaitForFunding as WaitForFundingB, 
-  Concluded as ConcludedB, 
+  WaitForFunding as WaitForFundingB,
+  Concluded as ConcludedB,
 } from '../../../game-engine/application-states/PlayerB';
+import { State } from 'fmg-core';
 
 // FUNDING
 // =======
@@ -41,12 +42,12 @@ export const VALIDATION_REQUEST = 'WALLET.VALIDATION.REQUEST';
 export const VALIDATION_SUCCESS = 'WALLET.VALIDATION.SUCCESS';
 export const VALIDATION_FAILURE = 'WALLET.VALIDATION.FAILURE';
 
-export const validationRequest = (requestId: string, positionData: string, signature:string, expectedAddress:string) => ({
+export const validationRequest = (requestId: string, positionData: string, signature: string, opponentIndex: number) => ({
   type: VALIDATION_REQUEST as typeof VALIDATION_REQUEST,
   requestId,
   positionData,
   signature,
-  expectedAddress,
+  opponentIndex,
 });
 export const validationSuccess = (requestId: string) => ({
   type: VALIDATION_SUCCESS as typeof VALIDATION_SUCCESS,
@@ -136,11 +137,6 @@ export const initializationFailure = (message: string) => ({
 
 export type InitializationSuccess = ReturnType<typeof initializationSuccess>;
 
-// Requests
-// ========
-
-export type RequestAction = FundingRequest | SignatureRequest | ValidationRequest | WithdrawalRequest;
-
 // MESSAGING
 // =========
 export const SEND_MESSAGE = 'WALLET.MESSAGING.SEND';
@@ -159,3 +155,34 @@ export const receiveMessage = (data: string) => ({
 
 export type SendMessage = ReturnType<typeof sendMessage>;
 export type ReceiveMessage = ReturnType<typeof receiveMessage>;
+
+// DECODING
+// ========
+export const DECODE_STATE_REQUEST = 'WAllET.DECODE.REQUEST';
+export const DECODE_STATE_SUCCESS = 'WAllET.DECODE.SUCCESS';
+export const DECODE_STATE_FAILURE = 'WAllET.DECODE.FAILURE';
+
+export const decodeStateRequest = (data: string) => ({
+  type: DECODE_STATE_REQUEST as typeof DECODE_STATE_REQUEST,
+  data,
+});
+
+export const decodeStateSuccess = (state: State, additionalData?: string) => ({
+  type: DECODE_STATE_SUCCESS as typeof DECODE_STATE_SUCCESS,
+  state,
+  additionalData,
+});
+
+export const decodeStateFailure = (message: string) => ({
+  type: DECODE_STATE_FAILURE as typeof DECODE_STATE_FAILURE,
+  message,
+});
+
+export type DecodeStateRequest = ReturnType<typeof decodeStateRequest>;
+export type DecodeStateSuccess = ReturnType<typeof decodeStateSuccess>;
+export type DecodeStateFailure = ReturnType<typeof decodeStateFailure>;
+export type DecodeStateResponse = DecodeStateFailure | DecodeStateSuccess;
+
+// Requests
+// ========
+export type RequestAction = FundingRequest | SignatureRequest | ValidationRequest | WithdrawalRequest | DecodeStateRequest;

--- a/src/wallet/redux/sagas/wallet.ts
+++ b/src/wallet/redux/sagas/wallet.ts
@@ -30,7 +30,7 @@ export function* walletSaga(uid: string): IterableIterator<any> {
         break;
 
       case actions.VALIDATION_REQUEST:
-        yield handleValidationRequest(action.requestId, action.signedPositionData);
+        yield handleValidationRequest(action.requestId, action.positionData, action.signature);
         break;
 
       case actions.FUNDING_REQUEST:
@@ -58,13 +58,17 @@ function* handleSignatureRequest(wallet: ChannelWallet, requestId, positionData)
   yield put(actions.signatureSuccess(requestId, signedPosition));
 }
 
-function* handleValidationRequest(requestId, data) {
+function* handleValidationRequest(requestId, data, signature) {
   // todo:
-  // - check the signature
+  // tslint:disable-next-line:no-console
+  console.log(web3.eth.accounts.recover(data, signature));
+  
+  
+  
   // - validate the transition
   // - store the position
 
-  yield put(actions.validationSuccess(requestId, data));
+  yield put(actions.validationSuccess(requestId));
 }
 
 function* handleFundingRequest(_wallet: ChannelWallet, channelId, state) {

--- a/src/wallet/redux/sagas/wallet.ts
+++ b/src/wallet/redux/sagas/wallet.ts
@@ -1,4 +1,4 @@
-import { actionChannel, take, put, fork, } from 'redux-saga/effects';
+import { actionChannel, take, put, fork } from 'redux-saga/effects';
 
 import { initializeWallet } from './initialization';
 import * as actions from '../actions/external';
@@ -19,8 +19,8 @@ export function* walletSaga(uid: string): IterableIterator<any> {
 
   yield put(actions.initializationSuccess(wallet.address));
 
-  while(true) {
-    const action: actions.RequestAction = yield take(channel)
+  while (true) {
+    const action: actions.RequestAction = yield take(channel);
 
     // The handlers below will block, so the wallet will only ever
     // process one action at a time from the queue.
@@ -30,7 +30,13 @@ export function* walletSaga(uid: string): IterableIterator<any> {
         break;
 
       case actions.VALIDATION_REQUEST:
-        yield handleValidationRequest(action.requestId, action.positionData, action.signature);
+        yield handleValidationRequest(
+          wallet,
+          action.requestId,
+          action.positionData,
+          action.signature,
+          action.expectedAddress,
+        );
         break;
 
       case actions.FUNDING_REQUEST:
@@ -38,12 +44,12 @@ export function* walletSaga(uid: string): IterableIterator<any> {
         break;
 
       default:
-        // const _exhaustiveCheck: never = action;
-        // todo: get this to work
-        // currently causes a 'noUnusedLocals' error on compilation
-        // underscored variables should be an exception but there seems to 
-        // be a bug in my current version of typescript
-        // https://github.com/Microsoft/TypeScript/issues/15053
+      // const _exhaustiveCheck: never = action;
+      // todo: get this to work
+      // currently causes a 'noUnusedLocals' error on compilation
+      // underscored variables should be an exception but there seems to
+      // be a bug in my current version of typescript
+      // https://github.com/Microsoft/TypeScript/issues/15053
     }
   }
 }
@@ -58,13 +64,18 @@ function* handleSignatureRequest(wallet: ChannelWallet, requestId, positionData)
   yield put(actions.signatureSuccess(requestId, signedPosition));
 }
 
-function* handleValidationRequest(requestId, data, signature) {
+function* handleValidationRequest(
+  wallet: ChannelWallet,
+  requestId,
+  data,
+  signature,
+  expectedAddress,
+) {
   // todo:
-  // tslint:disable-next-line:no-console
-  console.log(web3.eth.accounts.recover(data, signature));
-  
-  
-  
+  const address = wallet.recover(data, signature);
+  if (address !== expectedAddress) {
+    yield put(actions.validationFailure(requestId, 'INVALID SIGNATURE'));
+  }
   // - validate the transition
   // - store the position
 
@@ -74,7 +85,7 @@ function* handleValidationRequest(requestId, data, signature) {
 function* handleFundingRequest(_wallet: ChannelWallet, channelId, state) {
   let success;
   if (state.opponentAddress === AUTO_OPPONENT_ADDRESS) {
-    success = true
+    success = true;
   } else {
     success = yield fundingSaga(channelId, state);
   }

--- a/src/wallet/redux/sagas/wallet.ts
+++ b/src/wallet/redux/sagas/wallet.ts
@@ -42,7 +42,7 @@ export function* walletSaga(uid: string): IterableIterator<any> {
         break;
 
       case actions.FUNDING_REQUEST:
-        yield handleFundingRequest(wallet, action.channelId, action.state);
+        yield fork(handleFundingRequest,wallet, action.channelId, action.state);
         break;
       case actions.DECODE_STATE_REQUEST:
         yield handleDecodeRequest(action.data);

--- a/src/wallet/redux/sagas/wallet.ts
+++ b/src/wallet/redux/sagas/wallet.ts
@@ -16,7 +16,6 @@ export function* walletSaga(uid: string): IterableIterator<any> {
     actions.FUNDING_REQUEST,
     actions.SIGNATURE_REQUEST,
     actions.VALIDATION_REQUEST,
-    actions.DECODE_STATE_REQUEST,
   ]);
 
   yield put(actions.initializationSuccess(wallet.address));
@@ -42,10 +41,7 @@ export function* walletSaga(uid: string): IterableIterator<any> {
         break;
 
       case actions.FUNDING_REQUEST:
-        yield fork(handleFundingRequest,wallet, action.channelId, action.state);
-        break;
-      case actions.DECODE_STATE_REQUEST:
-        yield handleDecodeRequest(action.data);
+        yield fork(handleFundingRequest, wallet, action.channelId, action.state);
         break;
       default:
       // const _exhaustiveCheck: never = action;
@@ -58,11 +54,6 @@ export function* walletSaga(uid: string): IterableIterator<any> {
   }
 }
 
-function* handleDecodeRequest(data: string) {
-  const state = decode(data);
-  yield put(actions.decodeStateSuccess(state));
-
-}
 
 function* handleSignatureRequest(wallet: ChannelWallet, requestId, positionData) {
   // todo:

--- a/src/wallet/redux/sagas/wallet.ts
+++ b/src/wallet/redux/sagas/wallet.ts
@@ -6,7 +6,7 @@ import ChannelWallet from '../../domain/ChannelWallet';
 import { fundingSaga } from './funding';
 import { blockchainSaga } from './blockchain';
 import { AUTO_OPPONENT_ADDRESS } from '../../../constants';
-import decode, { GAME_ATTRIBUTE_OFFSET } from '../../domain/decode';
+import decode from '../../domain/decode';
 
 export function* walletSaga(uid: string): IterableIterator<any> {
   const wallet = yield initializeWallet(uid);
@@ -60,8 +60,7 @@ export function* walletSaga(uid: string): IterableIterator<any> {
 
 function* handleDecodeRequest(data: string) {
   const state = decode(data);
-  const additionalData = data.substr(GAME_ATTRIBUTE_OFFSET);
-  yield put(actions.decodeStateSuccess(state, additionalData));
+  yield put(actions.decodeStateSuccess(state));
 
 }
 

--- a/src/wallet/redux/sagas/wallet.ts
+++ b/src/wallet/redux/sagas/wallet.ts
@@ -53,7 +53,7 @@ function* handleSignatureRequest(wallet: ChannelWallet, requestId, positionData)
   // - validate the transition
   // - sign the position
   // - store the position
-  const signedPosition = wallet.sign(positionData)
+  const signedPosition = wallet.sign(positionData);
 
   yield put(actions.signatureSuccess(requestId, signedPosition));
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7675,6 +7675,10 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-hash@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.0.tgz#76d9ba6ff113cf8efc0d996102851fe6723963e2"
+
 object-inspect@^1.6.0, object-inspect@~1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"


### PR DESCRIPTION
We now sign and validate states as they are sent as messages. Decode logic for state from `fmg-core` has moved to the wallet while the game decode handles decoding game-specific state.  

We still need to handle signing wallet state.

closes #176