### PR TITLE
Handle timeout errors

### DIFF
--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -5,7 +5,7 @@ interface Props {
   error: string;
 }
 
-const initialState = { error: "Application Error" };
+const initialState = {};
 type State = Readonly<typeof initialState>;
 
 export default class ErrorPage extends React.PureComponent<Props, State> {
@@ -16,6 +16,6 @@ export default class ErrorPage extends React.PureComponent<Props, State> {
   }
 
   render() {
-    return <div> Error: {this.state.error} </div>;
+    return <div> Error: {this.props.error} </div>;
   }
 }

--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -1,0 +1,21 @@
+import _ from 'lodash';
+import React from 'react';
+
+interface Props {
+  error: string;
+}
+
+const initialState = { error: "Application Error" };
+type State = Readonly<typeof initialState>;
+
+export default class ErrorPage extends React.PureComponent<Props, State> {
+  readonly state: State = initialState;
+
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return <div> Error: {this.state.error} </div>;
+  }
+}

--- a/src/containers/ApplicationContainer.tsx
+++ b/src/containers/ApplicationContainer.tsx
@@ -5,6 +5,7 @@ import { SiteState } from '../redux/reducer';
 import GameContainer from './GameContainer';
 import WaitingRoomContainer from './WaitingRoomContainer';
 import LobbyContainer from './LobbyContainer';
+import ErrorContainer from './ErrorContainer';
 import { Room } from '../redux/application/reducer';
 
 interface ApplicationProps {
@@ -17,6 +18,8 @@ function Application(props: ApplicationProps) {
       return <WaitingRoomContainer />;
     case Room.game:
       return <GameContainer />;
+    case Room.error:
+      return <ErrorContainer />;
     default:
       return <LobbyContainer />;
   }

--- a/src/containers/ErrorContainer.tsx
+++ b/src/containers/ErrorContainer.tsx
@@ -1,0 +1,15 @@
+import { connect } from 'react-redux';
+
+import ErrorPage from '../components/ErrorPage';
+
+const mapStateToProps = (error: string) => ({
+  error,
+});
+
+const mapDispatchToProps = {
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ErrorPage);

--- a/src/containers/ErrorContainer.tsx
+++ b/src/containers/ErrorContainer.tsx
@@ -1,10 +1,11 @@
 import { connect } from 'react-redux';
 
 import ErrorPage from '../components/ErrorPage';
+import { SiteState } from '../redux/reducer';
 
-const mapStateToProps = (error: string) => ({
-  error,
-});
+const mapStateToProps = (state: SiteState) => {
+  return { error: state.app.error };
+};
 
 const mapDispatchToProps = {
 };

--- a/src/redux/application/actions.ts
+++ b/src/redux/application/actions.ts
@@ -4,6 +4,7 @@ import { Challenge } from "./reducer";
 import BN from 'bn.js';
 
 export const INITIALIZATION_FAILURE = 'APPLICATION.INITIALIZATION.FAILURE';
+export const RELOAD = 'APPLICATION.RELOAD';
 export const LOBBY_REQUEST = 'APPLICATION.LOBBY_REQUEST';
 export const WAITING_ROOM_REQUEST = 'APPLICATION.WAITING_ROOM_REQUEST';
 export const GAME_REQUEST = 'APPLICATION.GAME_REQUEST';
@@ -11,9 +12,9 @@ export const LOBBY_SUCCESS = 'APPLICATION.LOBBY_SUCCESS';
 export const WAITING_ROOM_SUCCESS = 'APPLICATION.WAITING_ROOM_SUCCESS';
 export const GAME_SUCCESS = 'APPLICATION.GAME_SUCCESS';
 
-export const initializationFailure = (reason) => ({
+export const initializationFailure = (error) => ({
   type: INITIALIZATION_FAILURE as typeof INITIALIZATION_FAILURE,
-  reason,
+  error,
 });
 
 export const lobbyRequest = () => ({

--- a/src/redux/application/actions.ts
+++ b/src/redux/application/actions.ts
@@ -3,12 +3,18 @@ import { State as GameState } from "../../game-engine/application-states";
 import { Challenge } from "./reducer";
 import BN from 'bn.js';
 
+export const INITIALIZATION_FAILURE = 'APPLICATION.INITIALIZATION.FAILURE';
 export const LOBBY_REQUEST = 'APPLICATION.LOBBY_REQUEST';
 export const WAITING_ROOM_REQUEST = 'APPLICATION.WAITING_ROOM_REQUEST';
 export const GAME_REQUEST = 'APPLICATION.GAME_REQUEST';
 export const LOBBY_SUCCESS = 'APPLICATION.LOBBY_SUCCESS';
 export const WAITING_ROOM_SUCCESS = 'APPLICATION.WAITING_ROOM_SUCCESS';
 export const GAME_SUCCESS = 'APPLICATION.GAME_SUCCESS';
+
+export const initializationFailure = (reason) => ({
+  type: INITIALIZATION_FAILURE as typeof INITIALIZATION_FAILURE,
+  reason,
+});
 
 export const lobbyRequest = () => ({
   type: LOBBY_REQUEST as typeof LOBBY_REQUEST,
@@ -40,6 +46,8 @@ export const gameSuccess = (state: GameState) => ({
 });
 
 
+export type InitializationFailure = ReturnType<typeof initializationFailure>;
+
 export type LobbyRequest = ReturnType<typeof lobbyRequest>;
 export type WaitingRoomRequest = ReturnType<typeof waitingRoomRequest>;
 export type GameRequest = ReturnType<typeof gameRequest>;
@@ -49,6 +57,7 @@ export type WaitingRoomSuccess = ReturnType<typeof waitingRoomSuccess>;
 export type GameSuccess = ReturnType<typeof gameSuccess>;
 
 export type AnyAction = 
+  | InitializationFailure
   | LobbyRequest
   | WaitingRoomRequest
   | GameRequest

--- a/src/redux/application/reducer.ts
+++ b/src/redux/application/reducer.ts
@@ -27,6 +27,7 @@ export interface ApplicationState {
   gameState?: GameState;
   challenges?: Challenge[];
   myChallenge?: Challenge;
+  error?: string;
 }
 
 const initialState = {

--- a/src/redux/application/reducer.ts
+++ b/src/redux/application/reducer.ts
@@ -10,6 +10,7 @@ export enum Room {
   lobby = 'ROOM.LOBBY',
   waitingRoom = 'ROOM.WAITING_ROOM',
   game = 'ROOM.GAME',
+  error = 'ROOM.ERROR',
 }
 
 export interface Challenge {
@@ -37,6 +38,7 @@ type StateAction =
   | applicationActions.LobbySuccess
   | applicationActions.WaitingRoomSuccess
   | applicationActions.GameSuccess
+  | applicationActions.InitializationFailure
   | gameActions.StateChanged
   | lobbyActions.SyncChallenge
   | lobbyActions.ExpireChallenges;
@@ -54,6 +56,12 @@ export const applicationReducer: Reducer<ApplicationState> = (state = initialSta
       return {
         currentRoom: Room.game,
         gameState: action.state,
+      };
+    case applicationActions.INITIALIZATION_FAILURE:
+      return {
+        ...state,
+        currentRoom: Room.error,
+        error: action.error,
       };
     case gameActions.STATE_CHANGED:
       return {

--- a/src/redux/application/saga.ts
+++ b/src/redux/application/saga.ts
@@ -14,14 +14,15 @@ import autoOpponentSaga from '../auto-opponent/saga';
 export default function* applicationControllerSaga(userId: string) {
   // need to yield* so that the fork(walletSaga) runs in the context of this saga -
   // otherwise it'll be killed when the setupWallet saga returns
-  const { address, failure } = yield call(setupWallet, userId);
+  const { error: autoOpponentError } = yield call(setupAutoOpponent);
+  const { address, error: walletError } = yield call(setupWallet, userId);
 
-  if (failure) {
-    yield put(applicationActions.initializationFailure("Wallet setup failed."));
-    return;
+  const error = autoOpponentError || walletError;
+
+  if (error) {
+    yield put(applicationActions.initializationFailure(error));
+    yield take(applicationActions.RELOAD);
   }
-
-  yield call(setupAutoOpponent);
 
   yield fork(messageServiceSaga, address);
 
@@ -29,9 +30,10 @@ export default function* applicationControllerSaga(userId: string) {
     applicationActions.LOBBY_REQUEST,
     applicationActions.WAITING_ROOM_REQUEST,
     applicationActions.GAME_REQUEST,
+    applicationActions.INITIALIZATION_FAILURE,
   ]);
   let currentRoom = yield fork(lobbySaga, address);
-  
+
   while (true) {
     const action: applicationActions.AnyAction = yield take(channel);
     yield cancel(currentRoom); // todo: maybe we should do some checks first
@@ -64,9 +66,10 @@ function* setupWallet(uid) {
   });
 
   if (failure) {
-    yield put(walletActions.initializationFailure('Wallet initialization timed out'));
+    const error = 'Wallet initialization timed out';
+    yield put(walletActions.initializationFailure(error));
     yield cancel(task);
-    return { failure };
+    return { error };
   } else {
     const address = (success as walletActions.InitializationSuccess).address;
 
@@ -84,7 +87,9 @@ function* setupAutoOpponent() {
     failure: call(delay, 2000),
   });
 
-  if (failure) { throw new Error('Auto-opponent initialization timed out'); }
+  if (failure) {
+    return { error: 'AutoOpponent failed to initialize' };
+  }
 
   const address = (success as autoOpponentActions.InitializationSuccess).address;
 

--- a/src/redux/application/saga.ts
+++ b/src/redux/application/saga.ts
@@ -14,7 +14,12 @@ import autoOpponentSaga from '../auto-opponent/saga';
 export default function* applicationControllerSaga(userId: string) {
   // need to yield* so that the fork(walletSaga) runs in the context of this saga -
   // otherwise it'll be killed when the setupWallet saga returns
-  const { address } = yield call(setupWallet, userId);
+  const { address, failure } = yield call(setupWallet, userId);
+
+  if (failure) {
+    yield put(applicationActions.initializationFailure("Wallet setup failed."));
+    return;
+  }
 
   yield call(setupAutoOpponent);
 
@@ -60,6 +65,8 @@ function* setupWallet(uid) {
 
   if (failure) {
     yield put(walletActions.initializationFailure('Wallet initialization timed out'));
+    yield cancel(task);
+    return { failure };
   } else {
     const address = (success as walletActions.InitializationSuccess).address;
 


### PR DESCRIPTION
The current behaviour actuall puts a `WALLET.INITIALIZATION.SUCCESS` action after the `WALLET.INITIALIZATION.FAILURE` action, and leaves you with a dead page.

![image](https://user-images.githubusercontent.com/8432675/46590531-db552500-ca68-11e8-8206-b47809193b9a.png)
