### PR TITLE
Removing Challenge updatedAt

### DIFF
--- a/src/redux/application/reducer.ts
+++ b/src/redux/application/reducer.ts
@@ -18,7 +18,6 @@ export interface Challenge {
   stake: BN;
   isPublic: boolean;
   createdAt: number;
-  updatedAt: number;
 }
 
 export interface ApplicationState {

--- a/src/redux/waiting-room/saga.ts
+++ b/src/redux/waiting-room/saga.ts
@@ -26,7 +26,6 @@ export default function* waitingRoomSaga(
     name,
     isPublic,
     createdAt: new Date().getTime(),
-    updatedAt: new Date().getTime(),
   };
 
   const challengeKey = `/challenges/${address}`;


### PR DESCRIPTION
Without heartbeats, this property is unused.

`createdAt` property is also unused. But `createdAt` is nice to have. As far as I know, there is no other way to find out the age of an object in Firebase.