### PR TITLE
Fix funding

### DIFF
--- a/src/wallet/redux/sagas/funding.ts
+++ b/src/wallet/redux/sagas/funding.ts
@@ -103,6 +103,7 @@ function* playerBFundingSaga(walletEngine: WalletEngine) {
   if (!(walletEngine.state instanceof PlayerB.WaitForApproval)) {
     throw new InvalidStateError(walletEngine.state);
   }
+  yield put(stateActions.stateChanged(walletEngine.state));
   const { myBalance } = walletEngine.state;
 
   let newState: PlayerB.PlayerBState = walletEngine.state;


### PR DESCRIPTION
The funding process is currently broken on master (player B's wallet displays a blank screen during funding). This PR fixes it.