### PR TITLE
Allow selecting a network

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -22,6 +22,7 @@ const publicPath = '/';
 const publicUrl = '';
 // Get environment variables to inject into our app.
 const env = getClientEnvironment(publicUrl);
+const deployContractsFromLoader = filename=>process.env.TARGET_NETWORK==='development';
 
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.
@@ -125,6 +126,7 @@ module.exports = {
         oneOf: [
           {
             test: /\.sol/,
+            include: deployContractsFromLoader,
             use: [
               {
                 loader: 'json-loader'
@@ -137,7 +139,7 @@ module.exports = {
               }
             ]
           },
-          {
+          { 
             test: /\.(scss)$/,
             use: [{
               loader: 'style-loader', // inject CSS to page
@@ -252,6 +254,12 @@ module.exports = {
     ],
   },
   plugins: [
+     // Instead of using the truffle loader we'll look for the already built truffle artifacts
+     new webpack.NormalModuleReplacementPlugin(
+      /.*\.sol/,
+      function(resource) {
+        resource.request = resource.request.replace(/.*contracts/, paths.appContractArtifacts).replace('.sol', '.json');
+      }),
     // Makes some environment variables available in index.html.
     // The public URL is available as %PUBLIC_URL% in index.html, e.g.:
     // <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
@@ -293,7 +301,8 @@ module.exports = {
     }),
     new webpack.EnvironmentPlugin({
     FIREBASE_PROJECT: 'rock-paper-scissors-dev',
-    FIREBASE_API_KEY: 'AIzaSyAlGe17xjJjfoJ_KDYjCREg7ZL4ns61Chc'
+    FIREBASE_API_KEY: 'AIzaSyAlGe17xjJjfoJ_KDYjCREg7ZL4ns61Chc',
+    TARGET_NETWORK: process.env.TARGET_NETWORK,
     })],
   // Some libraries import Node modules but don't use them in the browser.
   // Tell Webpack to provide empty mocks for them so importing them works.

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -22,8 +22,6 @@ const publicPath = '/';
 const publicUrl = '';
 // Get environment variables to inject into our app.
 const env = getClientEnvironment(publicUrl);
-const deployContractsFromLoader = filename=>process.env.TARGET_NETWORK==='development';
-
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.
 // The production configuration is different and lives in a separate file.
@@ -125,8 +123,10 @@ module.exports = {
         // back to the "file" loader at the end of the loader list.
         oneOf: [
           {
-            test: /\.sol/,
-            include: deployContractsFromLoader,
+            test: (path) => {
+              return process.env.TARGET_NETWORK==='development' &&
+              /\.sol$/.test(path);  
+          }, 
             use: [
               {
                 loader: 'json-loader'
@@ -139,7 +139,7 @@ module.exports = {
               }
             ]
           },
-          { 
+          {
             test: /\.(scss)$/,
             use: [{
               loader: 'style-loader', // inject CSS to page
@@ -258,7 +258,9 @@ module.exports = {
      new webpack.NormalModuleReplacementPlugin(
       /.*\.sol/,
       function(resource) {
-        resource.request = resource.request.replace(/.*contracts/, paths.appContractArtifacts).replace('.sol', '.json');
+        if (process.env.TARGET_NETWORK!=='development'){
+          resource.request = resource.request.replace(/.*contracts/, paths.appContractArtifacts).replace('.sol', '.json');
+        }
       }),
     // Makes some environment variables available in index.html.
     // The public URL is available as %PUBLIC_URL% in index.html, e.g.:

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -401,7 +401,8 @@ module.exports = {
       }),
       new webpack.EnvironmentPlugin({
         FIREBASE_PROJECT: 'rock-paper-scissors123',
-        FIREBASE_API_KEY: 'AIzaSyDulzMWkORgVPFwtxqQaTwOeNhOisGPtDs'
+        FIREBASE_API_KEY: 'AIzaSyDulzMWkORgVPFwtxqQaTwOeNhOisGPtDs',
+        TARGET_NETWORK: process.env.TARGET_NETWORK,
         })],
   // Some libraries import Node modules but don't use them in the browser.
   // Tell Webpack to provide empty mocks for them so importing them works.

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -397,9 +397,7 @@ module.exports = {
     new webpack.NormalModuleReplacementPlugin(
       /.*\.sol/,
       function(resource) {
-        const targetNetwork = process.env.TARGET_NETWORK;
-        const artifactsPath = path.join(paths.appContractArtifacts,targetNetwork);
-        resource.request = resource.request.replace(/.*contracts/,artifactsPath).replace('.sol','.json');
+        resource.request = resource.request.replace(/.*contracts/,paths.appContractArtifacts).replace('.sol','.json');
       }),
       new webpack.EnvironmentPlugin({
         FIREBASE_PROJECT: 'rock-paper-scissors123',

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -397,7 +397,7 @@ module.exports = {
     new webpack.NormalModuleReplacementPlugin(
       /.*\.sol/,
       function(resource) {
-        resource.request = resource.request.replace(/.*contracts/,paths.appContractArtifacts).replace('.sol','.json');
+        resource.request = resource.request.replace(/.*contracts/, paths.appContractArtifacts).replace('.sol', '.json');
       }),
       new webpack.EnvironmentPlugin({
         FIREBASE_PROJECT: 'rock-paper-scissors123',

--- a/contracts/artifacts/ForceMoveGame.json
+++ b/contracts/artifacts/ForceMoveGame.json
@@ -337,5 +337,5 @@
   },
   "networks": {},
   "schemaVersion": "3.0.0-beta.0",
-  "updatedAt": "2018-10-08T20:10:06.923Z"
+  "updatedAt": "2018-10-17T17:46:14.172Z"
 }

--- a/contracts/artifacts/Migrations.json
+++ b/contracts/artifacts/Migrations.json
@@ -1383,10 +1383,22 @@
     "3": {
       "events": {},
       "links": {},
-      "address": "0x496F488638398380490419127DE53E31E4A2654D",
-      "transactionHash": "0x5cf8b564dd27556025689177fb1a196f5cb11809fcd9dc404624756710c1bcf0"
+      "address": "0x53CE45d397eB69Bdc82c7004D34a746bD5356943",
+      "transactionHash": "0xc02fc89112f8c1a5e64f94217c97e7e0a9f0749def4bdd1150aeddf31e895f43"
+    },
+    "4": {
+      "events": {},
+      "links": {},
+      "address": "0x4b2C7a5d2C34452c20AEF8F67A11eA0F03B16557",
+      "transactionHash": "0x207d0958c4e84a8bb23e64c6d6d85cc0501683e5280ed257197781a3db83bd93"
+    },
+    "42": {
+      "events": {},
+      "links": {},
+      "address": "0x432641a8666cA6A288B0D09a30f571C47E19AB5E",
+      "transactionHash": "0xb333e1fd0d99079ea8d0649c2cc5d6d1d112c83da9d402c5bb00f7f08e01df1c"
     }
   },
   "schemaVersion": "3.0.0-beta.0",
-  "updatedAt": "2018-10-08T20:25:31.321Z"
+  "updatedAt": "2018-10-17T17:54:10.666Z"
 }

--- a/contracts/artifacts/RockPaperScissorsGame.json
+++ b/contracts/artifacts/RockPaperScissorsGame.json
@@ -15460,13 +15460,31 @@
     "3": {
       "events": {},
       "links": {
-        "RockPaperScissorsState": "0x92014B40325d9501BFb99882b7954249c10c05c9",
-        "State": "0x102c0CfBA6544143c3B9A883Aa768afDC5D8b546"
+        "RockPaperScissorsState": "0x55f70777E3cAa5f771d23a63308494D300828645",
+        "State": "0x181df94d2F3F1294e58284cB29b76DD1B347C6Fc"
       },
-      "address": "0x6D5d4C33B4ce1b9c0b87B556A54c07fF87e0eb35",
-      "transactionHash": "0xb53c832575946fe552040ae7b0456d522a96179aeac8401c237a5d90db829368"
+      "address": "0xA1796Db2b57144a2C21A92AE647B86B9641A47ac",
+      "transactionHash": "0xb5114eb9c8e39e8e3d634348c6303af04174436d116ca56e0e310bd2b8d37184"
+    },
+    "4": {
+      "events": {},
+      "links": {
+        "RockPaperScissorsState": "0xc046692059b6d62f78DE5Aaea6E75E13EFe943BB",
+        "State": "0x62248ff9316C9bB1c13B1171f4747F7225347D30"
+      },
+      "address": "0xB4848dd4Fa4fe9B6242c45702c56BA0745a8CA0c",
+      "transactionHash": "0x1831312d14f0f49b39619dd806d1d29e11e4c4c15093310b0f438b49176b5395"
+    },
+    "42": {
+      "events": {},
+      "links": {
+        "RockPaperScissorsState": "0x8e27c421CdBD8Ea5381c061A574b7270A145404c",
+        "State": "0xaA0424d6DE3b3F7b812b8B3fD80f70e0A24f7ea4"
+      },
+      "address": "0x8055e31544282dda09add5096E9870196Cdc0792",
+      "transactionHash": "0xc031115ee9fd30c7b2a981b16bb2fb2399b4390d5350f12e542e4f3daaf54cc1"
     }
   },
   "schemaVersion": "3.0.0-beta.0",
-  "updatedAt": "2018-10-08T20:25:31.360Z"
+  "updatedAt": "2018-10-17T17:54:10.777Z"
 }

--- a/contracts/artifacts/RockPaperScissorsState.json
+++ b/contracts/artifacts/RockPaperScissorsState.json
@@ -4806,12 +4806,28 @@
     "3": {
       "events": {},
       "links": {
-        "State": "0x102c0CfBA6544143c3B9A883Aa768afDC5D8b546"
+        "State": "0x181df94d2F3F1294e58284cB29b76DD1B347C6Fc"
       },
-      "address": "0x92014B40325d9501BFb99882b7954249c10c05c9",
-      "transactionHash": "0xa3843dcd72fee89e9b47458a329fdd400dbe1de32368a1967a6033b0c2d606c2"
+      "address": "0x55f70777E3cAa5f771d23a63308494D300828645",
+      "transactionHash": "0x34a45da0797173f59483fc77e4b763a664edc5adcee041ae963ebab289a3b0b0"
+    },
+    "4": {
+      "events": {},
+      "links": {
+        "State": "0x62248ff9316C9bB1c13B1171f4747F7225347D30"
+      },
+      "address": "0xc046692059b6d62f78DE5Aaea6E75E13EFe943BB",
+      "transactionHash": "0x037f7993d4c539511a088ddadbe4f90f9fdc33476425f390eca523d77621bb4d"
+    },
+    "42": {
+      "events": {},
+      "links": {
+        "State": "0xaA0424d6DE3b3F7b812b8B3fD80f70e0A24f7ea4"
+      },
+      "address": "0x8e27c421CdBD8Ea5381c061A574b7270A145404c",
+      "transactionHash": "0x585f6288b7b3e30cfd90f0109383919565bfb9c8c8a0ed674d5cbac1880216df"
     }
   },
   "schemaVersion": "3.0.0-beta.0",
-  "updatedAt": "2018-10-08T20:25:31.325Z"
+  "updatedAt": "2018-10-17T17:54:10.711Z"
 }

--- a/contracts/artifacts/Rules.json
+++ b/contracts/artifacts/Rules.json
@@ -19398,12 +19398,28 @@
     "3": {
       "events": {},
       "links": {
-        "State": "0x102c0CfBA6544143c3B9A883Aa768afDC5D8b546"
+        "State": "0x181df94d2F3F1294e58284cB29b76DD1B347C6Fc"
       },
-      "address": "0xDbAa8111445F16A08d4FAfEbD66E6622E52d9401",
-      "transactionHash": "0x2f3f52c5230c2e10eaac620b51a25ca18987793eb7949e93853c7726c7314abb"
+      "address": "0xdaB5CE23683741adCb02dF445B55dCc571BB0D25",
+      "transactionHash": "0x7345c87c519162196a5f67e76e83c4e442397452831b2b9ef39f5a826155049f"
+    },
+    "4": {
+      "events": {},
+      "links": {
+        "State": "0x62248ff9316C9bB1c13B1171f4747F7225347D30"
+      },
+      "address": "0xE4E59c4b05a1e4CD3C68c9a2EB501a571f5c9734",
+      "transactionHash": "0x68bbd03b2e7c59ebcfa1ed1a6c98b705c667a5aaf0ca7f53985f661d1ab24dcc"
+    },
+    "42": {
+      "events": {},
+      "links": {
+        "State": "0xaA0424d6DE3b3F7b812b8B3fD80f70e0A24f7ea4"
+      },
+      "address": "0xB984dF4E5Ca93D4Fa7eDdb64e4cce92645214D7F",
+      "transactionHash": "0xefda70639f58fd080a242d8e3b7fdf45bc77d87f23da30d9d1441a85201c0e59"
     }
   },
   "schemaVersion": "3.0.0-beta.0",
-  "updatedAt": "2018-10-08T20:25:31.395Z"
+  "updatedAt": "2018-10-17T17:54:10.799Z"
 }

--- a/contracts/artifacts/SimpleAdjudicator.json
+++ b/contracts/artifacts/SimpleAdjudicator.json
@@ -22448,11 +22448,25 @@
     "3": {
       "events": {},
       "links": {
-        "State": "0x102c0CfBA6544143c3B9A883Aa768afDC5D8b546",
-        "Rules": "0xDbAa8111445F16A08d4FAfEbD66E6622E52d9401"
+        "State": "0x181df94d2F3F1294e58284cB29b76DD1B347C6Fc",
+        "Rules": "0xdaB5CE23683741adCb02dF445B55dCc571BB0D25"
+      }
+    },
+    "4": {
+      "events": {},
+      "links": {
+        "State": "0x62248ff9316C9bB1c13B1171f4747F7225347D30",
+        "Rules": "0xE4E59c4b05a1e4CD3C68c9a2EB501a571f5c9734"
+      }
+    },
+    "42": {
+      "events": {},
+      "links": {
+        "State": "0xaA0424d6DE3b3F7b812b8B3fD80f70e0A24f7ea4",
+        "Rules": "0xB984dF4E5Ca93D4Fa7eDdb64e4cce92645214D7F"
       }
     }
   },
   "schemaVersion": "3.0.0-beta.0",
-  "updatedAt": "2018-10-08T20:25:31.382Z"
+  "updatedAt": "2018-10-17T17:54:10.790Z"
 }

--- a/contracts/artifacts/State.json
+++ b/contracts/artifacts/State.json
@@ -15102,10 +15102,22 @@
     "3": {
       "events": {},
       "links": {},
-      "address": "0x102c0CfBA6544143c3B9A883Aa768afDC5D8b546",
-      "transactionHash": "0x90d157a4d5a7c0238fe670630ce76056687b3949d49a7acda9e994fdff878434"
+      "address": "0x181df94d2F3F1294e58284cB29b76DD1B347C6Fc",
+      "transactionHash": "0xc304a749058c995176923e7308dd63260efbbd8d49deb50fd04f09107444f481"
+    },
+    "4": {
+      "events": {},
+      "links": {},
+      "address": "0x62248ff9316C9bB1c13B1171f4747F7225347D30",
+      "transactionHash": "0xf43644b65d75270e4497b680ca86b19ea43449c87d8afa881493d64fbc8aeb0d"
+    },
+    "42": {
+      "events": {},
+      "links": {},
+      "address": "0xaA0424d6DE3b3F7b812b8B3fD80f70e0A24f7ea4",
+      "transactionHash": "0xca0762d0829d15e7d48561fea5613323022728e06a8f0c0a19009cff48b1313a"
     }
   },
   "schemaVersion": "3.0.0-beta.0",
-  "updatedAt": "2018-10-08T20:25:31.343Z"
+  "updatedAt": "2018-10-17T17:54:10.767Z"
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -14,8 +14,6 @@ process.on('unhandledRejection', err => {
 // Ensure environment variables are read.
 require('../config/env');
 
-// Default to ropsten test network
-process.env.TARGET_NETWORK = process.env.TARGET_NETWORK || 'ropsten';
 process.env.DEFAULT_GAS = process.env.DEFAULT_GAS || 6721975;
 process.env.DEFAULT_GAS_PRICE = process.env.DEFAULT_GAS_PRICE || 20000000000;
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -13,7 +13,8 @@ process.on('unhandledRejection', err => {
 
 // Ensure environment variables are read.
 require('../config/env');
-
+// Default to ropsten test network
+process.env.TARGET_NETWORK = process.env.TARGET_NETWORK || 'ropsten';
 process.env.DEFAULT_GAS = process.env.DEFAULT_GAS || 6721975;
 process.env.DEFAULT_GAS_PRICE = process.env.DEFAULT_GAS_PRICE || 20000000000;
 

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -18,7 +18,8 @@ process.env.DEV_GANACHE_HOST = process.env.DEV_GANACHE_HOST || 'localhost';
 process.env.DEV_GANACHE_PORT = process.env.DEV_GANACHE_PORT || 7546;
 process.env.DEFAULT_GAS = process.env.DEFAULT_GAS || 6721975;
 process.env.DEFAULT_GAS_PRICE = process.env.DEFAULT_GAS_PRICE || 20000000000;
-
+// Default to the development network
+process.env.TARGET_NETWORK = process.env.TARGET_NETWORK || 'development';
 const fs = require('fs');
 const chalk = require('chalk');
 const webpack = require('webpack');

--- a/src/components/MetamaskErrorPage.tsx
+++ b/src/components/MetamaskErrorPage.tsx
@@ -7,13 +7,7 @@ interface MetamaskErrorProps {
 }
 
 export default function MetamaskErrorPage(props: MetamaskErrorProps) {
-  const networksTypes = {
-    1: 'mainnet',
-    2: 'morden',
-    3: 'ropsten',
-    42: 'kovan',
-    4: 'rinkeby',
-  };
+
   let message = (
     <span>
       This site needs to be connected to an ethereum wallet to function. If you have metamask,
@@ -24,14 +18,17 @@ export default function MetamaskErrorPage(props: MetamaskErrorProps) {
       .
     </span>
   );
-  if (props.error.errorType === 'WrongNetwork' && props.error.networkId) {
-    const type = networksTypes[props.error.networkId] || 'development';
+  if (props.error.errorType === 'WrongNetwork' && props.error.networkName) {
     message = (
       <span
-      >{`The wrong network is selected in your ethereum wallet. Please select the ${type} network in your ethereum wallet.`}</span>
+      >{`The wrong network is selected in metamask. Please select the ${props.error.networkName} network in metamask.`}</span>
     );
   }
-
+  if (props.error.errorType === "MetamaskLocked"){
+    message = (
+      <span>Your metamask account is currently locked. Please unlock it to continue.</span>
+    );
+  }
   return (
     <div className={css(styles.container)}>
       <div className={css(styles.headerText)}>

--- a/src/redux/metamask/actions.ts
+++ b/src/redux/metamask/actions.ts
@@ -1,10 +1,10 @@
 export const METAMASK_ERROR = 'METAMASK.ERROR';
 export const METAMASK_SUCCESS = 'METAMASK.SUCCESS';
-export const enum MetamaskErrorType {WrongNetwork="WrongNetwork", NoWeb3="NoWeb3"}
+export const enum MetamaskErrorType {WrongNetwork="WrongNetwork", NoWeb3="NoWeb3", MetamaskLocked= "MetamaskLocked"}
 
 export interface MetamaskError {
   errorType: MetamaskErrorType;
-  networkId?: number;
+  networkName?: string;
 }
 
 export const metamaskErrorOccurred = (error: MetamaskError) => ({

--- a/src/redux/metamask/saga.ts
+++ b/src/redux/metamask/saga.ts
@@ -1,7 +1,6 @@
 import * as metamaskActions from './actions';
 import { put, cps } from 'redux-saga/effects';
-// @ts-ignore
-import simpleAdjudicatorArtifact from 'fmg-simple-adjudicator/contracts/SimpleAdjudicator.sol';
+import truffle from 'truffle.js';
 import { MetamaskErrorType } from './actions';
 
 export default function* checkMetamask() {
@@ -14,17 +13,19 @@ export default function* checkMetamask() {
     return false;
   }
 
-  const selectedNetworkId = parseInt(yield cps(web3.version.getNetwork), 10);
-  // For development networks we can have multiple networks defined so we have to check all of them
-  if (!Object.keys(simpleAdjudicatorArtifact.networks).find(id=> parseInt(id,10) === selectedNetworkId)){
-    // We just grab the first network from the contract. In dev all the multiple networks will be called 'development'
-    // In non-dev environments there should only be only network 
-    const targetNetworkId = parseInt(Object.keys(simpleAdjudicatorArtifact.networks)[0], 10);
+  // TODO: Check if account is locked
 
+  const targetNetworkName = process.env.TARGET_NETWORK;
+  const selectedNetworkId = parseInt(yield cps(web3.version.getNetwork), 10);
+  // Find the network name that matches the currently selected network id
+  const selectedNetworkName = Object.keys(truffle.networks).find(networkName => 
+    truffle.networks[networkName].network_id === selectedNetworkId)|| "development";
+  
+    if (targetNetworkName !== selectedNetworkName) {
     yield put(
       metamaskActions.metamaskErrorOccurred({
         errorType: MetamaskErrorType.WrongNetwork,
-        networkId: targetNetworkId,
+        networkName: process.env.TARGET_NETWORK,
       }),
     );
     return false;

--- a/truffle.js
+++ b/truffle.js
@@ -1,10 +1,15 @@
 var HDWalletProvider = require("truffle-hdwallet-provider");
 require('dotenv').config()
 
-require('ts-node/register'); // To handle typescript dependencies in the test
+// We only want this loaded in a test environment 
+// so we can load and parse this file from the app
+if (process.env.NODE_ENV === 'test') {
+  require('ts-node/register'); 
+}
+
 require('babel-register'); // To handle es6 syntax in the tests
 
- module.exports = {
+module.exports = {
   networks: {
     development: {
       host: process.env.DEV_GANACHE_HOST,

--- a/truffle.js
+++ b/truffle.js
@@ -27,7 +27,7 @@ require('babel-register'); // To handle es6 syntax in the tests
     },
     kovan: {
       provider: () => new HDWalletProvider(process.env.ETH_ACCOUNT_MNENOMIC, "https://kovan.infura.io/v3/" + process.env.INFURA_API_KEY),
-      network_id: 5,
+      network_id: 42,
       gas: process.env.DEFAULT_GAS,
       gasPrice: process.env.DEFAULT_GAS_PRICE,
     },


### PR DESCRIPTION
adresses #212  and #156 

We now support building against multiple test networks. By default the prod build is ropsten and development is a local ganache instance.

However you can set the environment variable `TARGET_NETWORK` to override the defaults and to build against a target network.

I've also added support to run the dev server against a test net