### PR TITLE
Improve homepage styling

### DIFF
--- a/src/styles/home-page.scss
+++ b/src/styles/home-page.scss
@@ -1,7 +1,10 @@
 @import "./_colors";
 
 $loginButton-height: 44px;
-$background-image-size: 800px;
+$homePage-container-max-width: 70%;
+$background-image-size: contain;
+$background-image-width: 70%;
+$background-image-max-width: 800px;
 
 .homePage {
 	background-color: $rps-dark-blue;
@@ -13,14 +16,16 @@ $background-image-size: 800px;
 .homePage-container {
 	display: flex;
 	flex-direction: column;
-	padding-left: 20%;
+	padding-left: 15%;
 	padding-top: 25%;
+	max-width: $homePage-container-max-width;
 }
 
 .homePage-title-container {
 	display: flex;
 	flex-direction: column;
-	justify-content: flex-start
+	justify-content: flex-start;
+	max-width: 70%; 
 }
 
 .homePage-loginButton {
@@ -61,9 +66,10 @@ $background-image-size: 800px;
   background-image: url(images/homepage_image.png);
   background-repeat: no-repeat;
   background-size: $background-image-size;
-  height: $background-image-size;
+	height: 100%;
   position: absolute;
   right: 0px;
   top: 0px;
-  width: $background-image-size;
+  width: $background-image-width;
+  max-width: $background-image-max-width;
 }


### PR DESCRIPTION
The homepage still looks bad when the page is short, but it looks ok on mobile screens and narrow screens.

Typical phone:
<img width="361" alt="screen shot 2018-10-28 at 3 00 45 pm" src="https://user-images.githubusercontent.com/8432675/47621778-4ae78e80-dac2-11e8-9d1e-680a428d1574.png">

Small phone (Iphone 5/SE):
<img width="319" alt="screen shot 2018-10-28 at 3 00 34 pm" src="https://user-images.githubusercontent.com/8432675/47621783-58047d80-dac2-11e8-96b6-b2f4e94787d8.png">

Computer:
![homepage-styling](https://user-images.githubusercontent.com/8432675/47621930-2f7d8300-dac4-11e8-8ab0-2a2297146937.gif)


Fixes #250 
