### PR TITLE
Handle when Metamask throws exception during metamask check

### DIFF
--- a/src/components/MetamaskErrorPage.tsx
+++ b/src/components/MetamaskErrorPage.tsx
@@ -24,15 +24,20 @@ export default function MetamaskErrorPage(props: MetamaskErrorProps) {
       >{`The wrong network is selected in metamask. Please select the ${props.error.networkName} network in metamask.`}</span>
     );
   }
-  if (props.error.errorType === "MetamaskLocked"){
+  if (props.error.errorType === "MetamaskLocked") {
     message = (
       <span>Your metamask account is currently locked. Please unlock it to continue.</span>
+    );
+  }
+  if (props.error.errorType === "UnknownError") {
+    message = (
+      <span>Something went wrong while attempting to connect to metamask. Please ensure metamask is installed and working correctly.</span>
     );
   }
   return (
     <div className={css(styles.container)}>
       <div className={css(styles.headerText)}>
-        <h1 className={css(styles.title)}>Ethereum Wallet Error</h1>
+        <h1 className={css(styles.title)}>Metamask Error</h1>
         <p>{message}</p>
       </div>
     </div>

--- a/src/redux/metamask/actions.ts
+++ b/src/redux/metamask/actions.ts
@@ -1,6 +1,6 @@
 export const METAMASK_ERROR = 'METAMASK.ERROR';
 export const METAMASK_SUCCESS = 'METAMASK.SUCCESS';
-export const enum MetamaskErrorType {WrongNetwork="WrongNetwork", NoWeb3="NoWeb3", MetamaskLocked= "MetamaskLocked"}
+export const enum MetamaskErrorType {WrongNetwork="WrongNetwork", NoWeb3="NoWeb3", MetamaskLocked= "MetamaskLocked",UnknownError="UnknownError"}
 
 export interface MetamaskError {
   errorType: MetamaskErrorType;


### PR DESCRIPTION
Fixes #252 

Added a generic metamask error message and display that when we catch an exception trying to validate if metamask is installed. This should handle the case where the user is stuck connecting to an unknown network,