### PR TITLE
Switch TestEnvironment to jsdom

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "build": "node scripts/build.js",
     "test": "run-s test:truffle 'test:app --all'",
     "test:ci": "run-s build test:truffle 'test:app --all --ci'",
-    "test:app": "node scripts/test.js --env=jsdom",
+    "test:app": "node scripts/test.js",
     "test:truffle": "node scripts/test_truffle.js",
     "truffle:migrate": "deploy-contracts",
     "ganache:start": "start-ganache",
@@ -132,7 +132,7 @@
     "testMatch": [
       "<rootDir>/src/**/?(*.)(spec|test).(j|t)s?(x)"
     ],
-    "testEnvironment": "node",
+    "testEnvironment": "jsdom",
     "testURL": "http://localhost",
     "transform": {
       "^.+\\.(js|jsx|mjs)$": "<rootDir>/node_modules/babel-jest",


### PR DESCRIPTION
Switch TestEnvironment to jsdom so we don't have to pass `--env=jsdom` into `jest` and the jest extension will work for all tests.