### PR TITLE
Concluding and Withdrawing

### DIFF
--- a/src/wallet/__stories__/index.tsx
+++ b/src/wallet/__stories__/index.tsx
@@ -105,4 +105,4 @@ storiesOf('Wallet Screens / Responding', module)
 storiesOf('Wallet Screens / Closing', module)
   .add('ApproveConclude', testState(states.approveConclude(playerADefaults)))
   .add('WaitForOpponentConclude', testState(states.waitForOpponentConclude(playerADefaults)))
-  .add('AcknowledgeConcludeSuccess', testState(states.acknowledgeConcludeSuccess(playerADefaults)));
+  .add('AcknowledgeConcludeSuccess', testState(states.approveCloseOnChain(playerADefaults)));

--- a/src/wallet/containers/Closing.tsx
+++ b/src/wallet/containers/Closing.tsx
@@ -9,12 +9,15 @@ import AcknowledgeX from '../components/AcknowledgeX';
 import ApproveX from '../components/ApproveX';
 import { unreachable } from '../utils/reducer-utils';
 import WaitForOtherPlayer from '../components/WaitForOtherPlayer';
+import WaitForXConfirmation from '../components/WaitForXConfirmation';
+import WaitForXInitiation from '../components/WaitForXInitiation';
 
 interface Props {
   state: states.ClosingState;
   concludeApproved: () => void;
   concludeRejected: () => void;
   concludeSuccessAcknowledged: () => void;
+  closeOnChain: () => void;
   closeSuccessAcknowledged: () => void;
   closedOnChainAcknowledged: () => void;
 }
@@ -25,9 +28,9 @@ class ClosingContainer extends PureComponent<Props> {
       state,
       concludeApproved,
       concludeRejected,
-      concludeSuccessAcknowledged,
       closeSuccessAcknowledged,
       closedOnChainAcknowledged,
+      closeOnChain,
     } = this.props;
 
     switch (state.type) {
@@ -42,13 +45,13 @@ class ClosingContainer extends PureComponent<Props> {
         );
       case states.WAIT_FOR_OPPONENT_CONCLUDE:
         return <WaitForOtherPlayer name="conclude" />;
-      case states.ACKNOWLEDGE_CONCLUDE_SUCCESS:
+      case states.APPROVE_CLOSE_ON_CHAIN:
         return (
           <AcknowledgeX
-            title="Conclude successfull!"
-            action={concludeSuccessAcknowledged}
-            description="You have successfully concluded your channel"
-            actionTitle="Proceed to withdraw"
+            title="Game concluded!"
+            action={closeOnChain}
+            description="Send close trans"
+            actionTitle="Close channel"
           />
         );
       case states.ACKNOWLEDGE_CLOSE_SUCCESS:
@@ -69,7 +72,12 @@ class ClosingContainer extends PureComponent<Props> {
             actionTitle="Ok!"
           />
         );
-
+      case states.WAIT_FOR_CLOSE_INITIATION:
+        return <WaitForXInitiation name="close" />;
+      case states.WAIT_FOR_CLOSE_SUBMISSION:
+        return <WaitForXConfirmation name="close" />;
+      case states.WAIT_FOR_CLOSE_CONFIRMED:
+        return <WaitForXConfirmation name="close" />;
       default:
         return unreachable(state);
     }
@@ -82,6 +90,7 @@ const mapDispatchToProps = {
   concludeSuccessAcknowledged: actions.concludeSuccessAcknowledged,
   closeSuccessAcknowledged: actions.closeSuccessAcknowledged,
   closedOnChainAcknowledged: actions.closedOnChainAcknowledged,
+  closeOnChain: actions.approveClose,
 };
 
 export default connect(

--- a/src/wallet/containers/Closing.tsx
+++ b/src/wallet/containers/Closing.tsx
@@ -16,7 +16,6 @@ interface Props {
   state: states.ClosingState;
   concludeApproved: () => void;
   concludeRejected: () => void;
-  concludeSuccessAcknowledged: () => void;
   closeOnChain: () => void;
   closeSuccessAcknowledged: () => void;
   closedOnChainAcknowledged: () => void;
@@ -37,8 +36,8 @@ class ClosingContainer extends PureComponent<Props> {
       case states.APPROVE_CONCLUDE:
         return (
           <ApproveX
-            title="Conclude the channel!"
-            description="Do you wish to conclude this channel?"
+            title="Conclude the game!"
+            description="Do you wish to conclude this game?"
             approvalAction={concludeApproved}
             rejectionAction={concludeRejected}
           />
@@ -46,11 +45,12 @@ class ClosingContainer extends PureComponent<Props> {
       case states.WAIT_FOR_OPPONENT_CONCLUDE:
         return <WaitForOtherPlayer name="conclude" />;
       case states.APPROVE_CLOSE_ON_CHAIN:
+        // TODO: Add option to reject closing the channel?  
         return (
           <AcknowledgeX
-            title="Game concluded!"
+            title="Close Channel!"
             action={closeOnChain}
-            description="Send close trans"
+            description="The game has been concluded and the channel can now be closed."
             actionTitle="Close channel"
           />
         );
@@ -87,7 +87,6 @@ class ClosingContainer extends PureComponent<Props> {
 const mapDispatchToProps = {
   concludeApproved: actions.concludeApproved,
   concludeRejected: actions.concludeRejected,
-  concludeSuccessAcknowledged: actions.concludeSuccessAcknowledged,
   closeSuccessAcknowledged: actions.closeSuccessAcknowledged,
   closedOnChainAcknowledged: actions.closedOnChainAcknowledged,
   closeOnChain: actions.approveClose,

--- a/src/wallet/containers/Withdrawing.tsx
+++ b/src/wallet/containers/Withdrawing.tsx
@@ -29,6 +29,7 @@ class WithdrawingContainer extends PureComponent<Props> {
 
     switch (state.type) {
       case states.APPROVE_WITHDRAWAL:
+
         return (
           <ApproveX
             title="Withdraw your funds"

--- a/src/wallet/redux/actions/index.ts
+++ b/src/wallet/redux/actions/index.ts
@@ -194,7 +194,7 @@ export const transactionSentToMetamask = () => ({
 export type TransactionSentToMetamask = ReturnType<typeof transactionSentToMetamask>;
 
 export const TRANSACTION_SUBMISSION_FAILED = 'WALLET.TRANSACTION_SUBMISSION_FAILED';
-export const transactionSubmissionFailed = (error) => ({
+export const transactionSubmissionFailed = (error: { message?: string, code }) => ({
   error,
   type: TRANSACTION_SUBMISSION_FAILED as typeof TRANSACTION_SUBMISSION_FAILED,
 });

--- a/src/wallet/redux/actions/index.ts
+++ b/src/wallet/redux/actions/index.ts
@@ -323,8 +323,13 @@ export const closedOnChainAcknowledged = () => ({
 });
 export type ClosedOnChainAcknowledged = ReturnType<typeof closedOnChainAcknowledged>;
 
+export const APPROVE_CLOSE = 'APPROVE_CLOSE';
+export const approveClose = () => ({
+  type: APPROVE_CLOSE as typeof APPROVE_CLOSE,
+});
+export type ApproveClose = ReturnType<typeof approveClose>;
 
-// TODO: This is getting large, we should probably split this up into seperate types for each stage
+// TODO: This is getting large, we should probably split this up into separate types for each stage
 export type WalletAction = (
   | LoggedIn
   | KeysLoaded
@@ -369,4 +374,5 @@ export type WalletAction = (
   | ClosedOnChainAcknowledged
   | RespondWithMoveEvent
   | ChallengePositionReceived
+  | ApproveClose
 );

--- a/src/wallet/redux/actions/index.ts
+++ b/src/wallet/redux/actions/index.ts
@@ -304,13 +304,6 @@ export const concludeRejected = () => ({
 });
 export type ConcludeRejected = ReturnType<typeof concludeRejected>;
 
-
-export const CONCLUDE_SUCCESS_ACKNOWLEDGED = 'WALLET.CONCLUDE_SUCCESS_ACKNOWLEDGED';
-export const concludeSuccessAcknowledged = () => ({
-  type: CONCLUDE_SUCCESS_ACKNOWLEDGED as typeof CONCLUDE_SUCCESS_ACKNOWLEDGED,
-});
-export type ConcludeSuccessAcknowledged = ReturnType<typeof concludeSuccessAcknowledged>;
-
 export const CLOSE_SUCCESS_ACKNOWLEDGED = 'WALLET.CLOSE_SUCCESS_ACKNOWLEDGED';
 export const closeSuccessAcknowledged = () => ({
   type: CLOSE_SUCCESS_ACKNOWLEDGED as typeof CLOSE_SUCCESS_ACKNOWLEDGED,
@@ -369,7 +362,6 @@ export type WalletAction = (
   | GameConcludedEvent
   | ConcludeRequested
   | ConcludeApproved
-  | ConcludeSuccessAcknowledged
   | CloseSuccessAcknowledged
   | ClosedOnChainAcknowledged
   | RespondWithMoveEvent

--- a/src/wallet/redux/reducers/__tests__/closing.test.ts
+++ b/src/wallet/redux/reducers/__tests__/closing.test.ts
@@ -61,9 +61,17 @@ describe('start in ApproveConclude', () => {
     });
 
     const action = actions.concludeApproved();
-    const updatedState = walletReducer(state, action);
-    itTransitionsToStateType(states.APPROVE_CLOSE_ON_CHAIN, updatedState);
-    expect((updatedState.messageOutbox!).type).toEqual(outgoing.SEND_MESSAGE);
+    describe(' where the adjudicator exists', () => {
+      const updatedState = walletReducer(state, action);
+      itTransitionsToStateType(states.APPROVE_CLOSE_ON_CHAIN, updatedState);
+      expect((updatedState.messageOutbox!).type).toEqual(outgoing.SEND_MESSAGE);
+    });
+    describe(' where the adjudicator does not exist', () => {
+      state.adjudicator = undefined;
+      const updatedState = walletReducer(state, action);
+      itTransitionsToStateType(states.ACKNOWLEDGE_CLOSE_SUCCESS, updatedState);
+      expect((updatedState.messageOutbox!).type).toEqual(outgoing.CONCLUDE_SUCCESS);
+    });
   });
 
 });
@@ -78,9 +86,17 @@ describe('start in WaitForOpponentConclude', () => {
     });
 
     const action = actions.messageReceived(aResignsAfterOneRound.conclude2Hex, aResignsAfterOneRound.conclude2Sig);
-    const updatedState = walletReducer(state, action);
-    itTransitionsToStateType(states.APPROVE_CLOSE_ON_CHAIN, updatedState);
-    expect((updatedState.messageOutbox!).type).toEqual(outgoing.CONCLUDE_SUCCESS);
+    describe(' where the adjudicator exists', () => {
+      const updatedState = walletReducer(state, action);
+      itTransitionsToStateType(states.APPROVE_CLOSE_ON_CHAIN, updatedState);
+      expect((updatedState.messageOutbox!).type).toEqual(outgoing.CONCLUDE_SUCCESS);
+    });
+    describe(' where the adjudicator does not exist', () => {
+      state.adjudicator = undefined;
+      const updatedState = walletReducer(state, action);
+      itTransitionsToStateType(states.ACKNOWLEDGE_CLOSE_SUCCESS, updatedState);
+      expect((updatedState.messageOutbox!).type).toEqual(outgoing.CONCLUDE_SUCCESS);
+    });
   });
 });
 

--- a/src/wallet/redux/reducers/__tests__/closing.test.ts
+++ b/src/wallet/redux/reducers/__tests__/closing.test.ts
@@ -85,62 +85,85 @@ describe('start in WaitForOpponentConclude', () => {
 });
 
 describe('start in ApproveCloseOnChain', () => {
+  const state = states.approveCloseOnChain({
+    ...defaultsA,
+    penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: aResignsAfterOneRound.conclude2Sig },
+    lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: aResignsAfterOneRound.conclude2Sig },
+    turnNum: 9,
+  });
   describe('action taken: approve close on chain', () => {
-
-    const state = states.approveCloseOnChain({
-      ...defaultsA,
-      penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: aResignsAfterOneRound.conclude2Sig },
-      lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: aResignsAfterOneRound.conclude2Sig },
-      turnNum: 9,
-    });
     // TODO: Mock out Signature contructor so we don't have to pass a valid signature string in 
     const createConcludeTxMock = jest.fn();
     Object.defineProperty(TransactionGenerator, 'createConcludeTransaction', { value: createConcludeTxMock });
     const action = actions.approveClose();
     const updatedState = walletReducer(state, action);
     itTransitionsToStateType(states.WAIT_FOR_CLOSE_INITIATION, updatedState);
-
   });
+
+  describe('action taken: game concluded event', () => {
+    const action = actions.gameConcludedEvent();
+    const updatedState = walletReducer(state, action);
+    itTransitionsToStateType(states.APPROVE_WITHDRAWAL, updatedState);
+  });
+
 });
 
 describe('start in WaitForCloseInitiation', () => {
+  const state = states.waitForCloseInitiation({
+    ...defaultsA,
+    penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: aResignsAfterOneRound.conclude2Sig },
+    lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: aResignsAfterOneRound.conclude2Sig },
+    turnNum: 9,
+  });
   describe('action taken: transaction sent to metamask', () => {
-    const state = states.waitForCloseInitiation({
-      ...defaultsA,
-      penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: aResignsAfterOneRound.conclude2Sig },
-      lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: aResignsAfterOneRound.conclude2Sig },
-      turnNum: 9,
-    });
+
     const action = actions.transactionSentToMetamask();
     const updatedState = walletReducer(state, action);
     itTransitionsToStateType(states.WAIT_FOR_CLOSE_SUBMISSION, updatedState);
   });
+  describe('action taken: game concluded event', () => {
+    const action = actions.gameConcludedEvent();
+    const updatedState = walletReducer(state, action);
+    itTransitionsToStateType(states.APPROVE_WITHDRAWAL, updatedState);
+  });
 });
 
 describe('start in WaitForCloseSubmission', () => {
+  const state = states.waitForCloseSubmission({
+    ...defaultsA,
+    penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: aResignsAfterOneRound.conclude2Sig },
+    lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: aResignsAfterOneRound.conclude2Sig },
+    turnNum: 9,
+  });
   describe('action taken: transaction submitted', () => {
-    const state = states.waitForCloseSubmission({
-      ...defaultsA,
-      penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: aResignsAfterOneRound.conclude2Sig },
-      lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: aResignsAfterOneRound.conclude2Sig },
-      turnNum: 9,
-    });
+
     const action = actions.transactionSubmitted();
     const updatedState = walletReducer(state, action);
     itTransitionsToStateType(states.WAIT_FOR_CLOSE_CONFIRMED, updatedState);
+  });
+  describe('action taken: game concluded event', () => {
+    const action = actions.gameConcludedEvent();
+    const updatedState = walletReducer(state, action);
+    itTransitionsToStateType(states.APPROVE_WITHDRAWAL, updatedState);
   });
 });
 
 
 describe('start in WaitForCloseConfirmed', () => {
+  const state = states.waitForCloseConfirmed({
+    ...defaultsA,
+    penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: aResignsAfterOneRound.conclude2Sig },
+    lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: aResignsAfterOneRound.conclude2Sig },
+    turnNum: 9,
+  });
   describe('action taken: transaction confirmed', () => {
-    const state = states.waitForCloseConfirmed({
-      ...defaultsA,
-      penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: aResignsAfterOneRound.conclude2Sig },
-      lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: aResignsAfterOneRound.conclude2Sig },
-      turnNum: 9,
-    });
+
     const action = actions.transactionConfirmed();
+    const updatedState = walletReducer(state, action);
+    itTransitionsToStateType(states.APPROVE_WITHDRAWAL, updatedState);
+  });
+  describe('action taken: game concluded event', () => {
+    const action = actions.gameConcludedEvent();
     const updatedState = walletReducer(state, action);
     itTransitionsToStateType(states.APPROVE_WITHDRAWAL, updatedState);
   });

--- a/src/wallet/redux/reducers/__tests__/closing.test.ts
+++ b/src/wallet/redux/reducers/__tests__/closing.test.ts
@@ -3,7 +3,7 @@ import { walletReducer } from '..';
 import * as states from '../../../states';
 import * as actions from '../../actions';
 import * as outgoing from '../../../interface/outgoing';
-
+import * as TransactionGenerator from '../../../utils/transaction-generator';
 import { scenarios } from '../../../../core';
 import { itTransitionsToStateType } from './helpers';
 
@@ -19,7 +19,7 @@ const {
 } = scenarios.standard;
 
 const aResignsAfterOneRound = scenarios.aResignsAfterOneRound;
-// const bResignsAfterOneRound = scenarios.bResignsAfterOneRound;
+const bResignsAfterOneRound = scenarios.bResignsAfterOneRound;
 
 const defaults = {
   adjudicator: 'adj-address',
@@ -52,81 +52,112 @@ describe('start in ApproveConclude', () => {
     itTransitionsToStateType(states.WAIT_FOR_OPPONENT_CONCLUDE, updatedState);
   });
 
-  //   describe('action taken: conclude approved, second conclude state', () => {
-  //     const state = states.approveConclude({
-  //       ...defaultsA,
-  //       penultimatePosition: { data: proposeHex, signature: 'sig' },
-  //       lastPosition: { data: bResignsAfterOneRound.concludeHex, signature: 'sig' },
-  //       turnNum: 1,
-  //     });
-
-  //     const action = actions.concludeApproved();
-  //     const updatedState = walletReducer(state, action);
-  //     itTransitionsToStateType(states.ACKNOWLEDGE_CONCLUDE_SUCCESS, updatedState);
-  //     expect((updatedState.messageOutbox!).type).toEqual(outgoing.SEND_MESSAGE);
-  //   });
-
-  // });
-
-  // describe('start in WaitForOpponentConclude', () => {
-  //   describe('action taken: messageReceived', () => {
-  //     const state = states.waitForOpponentConclude({
-  //       ...defaultsA,
-  //       penultimatePosition: { data: aResignsAfterOneRound.restingHex, signature: 'sig' },
-  //       lastPosition: { data: aResignsAfterOneRound.concludeHex, signature: 'sig' },
-  //       turnNum: 8,
-  //     });
-
-  // const action = actions.messageReceived(aResignsAfterOneRound.conclude2Hex, aResignsAfterOneRound.conclude2Sig);
-  // const updatedState = walletReducer(state, action);
-  // itTransitionsToStateType(states.ACKNOWLEDGE_CONCLUDE_SUCCESS, updatedState);
-  //   });
-  // });
-
-  // describe('start in AcknowledgConcludeSuccess', () => {
-  //   describe('action taken: conclude success acknowledged', () => {
-  //     const state = states.acknowledgeConcludeSuccess({
-  //       ...defaultsA,
-  //       penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: 'sig' },
-  //       lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: 'sig' },
-  //       turnNum: 9,
-  //     });
-
-  //     const action = actions.concludeSuccessAcknowledged();
-  //     const updatedState = walletReducer(state, action);
-  //     itTransitionsToStateType(states.APPROVE_WITHDRAWAL, updatedState);
-  //     expect((updatedState.messageOutbox!).type).toEqual(outgoing.CONCLUDE_SUCCESS);
-  //   });
-
-  //   describe('action taken: conclude success acknowledged, adjudicator does not exist', () => {
-  //     const state = states.acknowledgeConcludeSuccess({
-  //       ...defaultsA,
-  //       penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: 'sig' },
-  //       lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: 'sig' },
-  //       turnNum: 9,
-  //       adjudicator: undefined,
-  //     });
-
-  //     const action = actions.concludeSuccessAcknowledged();
-  //     const updatedState = walletReducer(state, action);
-  //     itTransitionsToStateType(states.ACKNOWLEDGE_CLOSE_SUCCESS, updatedState);
-  //     expect((updatedState.messageOutbox!).type).toEqual(outgoing.CONCLUDE_SUCCESS);
-  //   });
-
-  // });
-
-  describe('start in AcknowledgCloseSuccess', () => {
-    describe('action taken: close success acknowledged', () => {
-      const state = states.acknowledgeCloseSuccess({
-        ...defaultsA,
-        penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: 'sig' },
-        lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: 'sig' },
-        turnNum: 9,
-      });
-
-      const action = actions.closeSuccessAcknowledged();
-      const updatedState = walletReducer(state, action);
-      itTransitionsToStateType(states.WAIT_FOR_CHANNEL, updatedState);
-      expect((updatedState.messageOutbox!).type).toEqual(outgoing.CLOSE_SUCCESS);
+  describe('action taken: conclude approved, second conclude state', () => {
+    const state = states.approveConclude({
+      ...defaultsA,
+      penultimatePosition: { data: proposeHex, signature: 'sig' },
+      lastPosition: { data: bResignsAfterOneRound.concludeHex, signature: 'sig' },
+      turnNum: 1,
     });
+
+    const action = actions.concludeApproved();
+    const updatedState = walletReducer(state, action);
+    itTransitionsToStateType(states.APPROVE_CLOSE_ON_CHAIN, updatedState);
+    expect((updatedState.messageOutbox!).type).toEqual(outgoing.SEND_MESSAGE);
   });
+
+});
+
+describe('start in WaitForOpponentConclude', () => {
+  describe('action taken: messageReceived', () => {
+    const state = states.waitForOpponentConclude({
+      ...defaultsA,
+      penultimatePosition: { data: aResignsAfterOneRound.restingHex, signature: 'sig' },
+      lastPosition: { data: aResignsAfterOneRound.concludeHex, signature: 'sig' },
+      turnNum: 8,
+    });
+
+    const action = actions.messageReceived(aResignsAfterOneRound.conclude2Hex, aResignsAfterOneRound.conclude2Sig);
+    const updatedState = walletReducer(state, action);
+    itTransitionsToStateType(states.APPROVE_CLOSE_ON_CHAIN, updatedState);
+    expect((updatedState.messageOutbox!).type).toEqual(outgoing.CONCLUDE_SUCCESS);
+  });
+});
+
+describe('start in ApproveCloseOnChain', () => {
+  describe('action taken: approve close on chain', () => {
+
+    const state = states.approveCloseOnChain({
+      ...defaultsA,
+      penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: aResignsAfterOneRound.conclude2Sig },
+      lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: aResignsAfterOneRound.conclude2Sig },
+      turnNum: 9,
+    });
+    // TODO: Mock out Signature contructor so we don't have to pass a valid signature string in 
+    const createConcludeTxMock = jest.fn();
+    Object.defineProperty(TransactionGenerator, 'createConcludeTransaction', { value: createConcludeTxMock });
+    const action = actions.approveClose();
+    const updatedState = walletReducer(state, action);
+    itTransitionsToStateType(states.WAIT_FOR_CLOSE_INITIATION, updatedState);
+
+  });
+});
+
+describe('start in WaitForCloseInitiation', () => {
+  describe('action taken: transaction sent to metamask', () => {
+    const state = states.waitForCloseInitiation({
+      ...defaultsA,
+      penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: aResignsAfterOneRound.conclude2Sig },
+      lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: aResignsAfterOneRound.conclude2Sig },
+      turnNum: 9,
+    });
+    const action = actions.transactionSentToMetamask();
+    const updatedState = walletReducer(state, action);
+    itTransitionsToStateType(states.WAIT_FOR_CLOSE_SUBMISSION, updatedState);
+  });
+});
+
+describe('start in WaitForCloseSubmission', () => {
+  describe('action taken: transaction submitted', () => {
+    const state = states.waitForCloseSubmission({
+      ...defaultsA,
+      penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: aResignsAfterOneRound.conclude2Sig },
+      lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: aResignsAfterOneRound.conclude2Sig },
+      turnNum: 9,
+    });
+    const action = actions.transactionSubmitted();
+    const updatedState = walletReducer(state, action);
+    itTransitionsToStateType(states.WAIT_FOR_CLOSE_CONFIRMED, updatedState);
+  });
+});
+
+
+describe('start in WaitForCloseConfirmed', () => {
+  describe('action taken: transaction confirmed', () => {
+    const state = states.waitForCloseConfirmed({
+      ...defaultsA,
+      penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: aResignsAfterOneRound.conclude2Sig },
+      lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: aResignsAfterOneRound.conclude2Sig },
+      turnNum: 9,
+    });
+    const action = actions.transactionConfirmed();
+    const updatedState = walletReducer(state, action);
+    itTransitionsToStateType(states.APPROVE_WITHDRAWAL, updatedState);
+  });
+});
+
+describe('start in AcknowledgCloseSuccess', () => {
+  describe('action taken: close success acknowledged', () => {
+    const state = states.acknowledgeCloseSuccess({
+      ...defaultsA,
+      penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: 'sig' },
+      lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: 'sig' },
+      turnNum: 9,
+    });
+
+    const action = actions.closeSuccessAcknowledged();
+    const updatedState = walletReducer(state, action);
+    itTransitionsToStateType(states.WAIT_FOR_CHANNEL, updatedState);
+    expect((updatedState.messageOutbox!).type).toEqual(outgoing.CLOSE_SUCCESS);
+  });
+});

--- a/src/wallet/redux/reducers/__tests__/closing.test.ts
+++ b/src/wallet/redux/reducers/__tests__/closing.test.ts
@@ -19,7 +19,7 @@ const {
 } = scenarios.standard;
 
 const aResignsAfterOneRound = scenarios.aResignsAfterOneRound;
-const bResignsAfterOneRound = scenarios.bResignsAfterOneRound;
+// const bResignsAfterOneRound = scenarios.bResignsAfterOneRound;
 
 const defaults = {
   adjudicator: 'adj-address',
@@ -52,81 +52,81 @@ describe('start in ApproveConclude', () => {
     itTransitionsToStateType(states.WAIT_FOR_OPPONENT_CONCLUDE, updatedState);
   });
 
-  describe('action taken: conclude approved, second conclude state', () => {
-    const state = states.approveConclude({
-      ...defaultsA,
-      penultimatePosition: { data: proposeHex, signature: 'sig' },
-      lastPosition: { data: bResignsAfterOneRound.concludeHex, signature: 'sig' },
-      turnNum: 1,
+  //   describe('action taken: conclude approved, second conclude state', () => {
+  //     const state = states.approveConclude({
+  //       ...defaultsA,
+  //       penultimatePosition: { data: proposeHex, signature: 'sig' },
+  //       lastPosition: { data: bResignsAfterOneRound.concludeHex, signature: 'sig' },
+  //       turnNum: 1,
+  //     });
+
+  //     const action = actions.concludeApproved();
+  //     const updatedState = walletReducer(state, action);
+  //     itTransitionsToStateType(states.ACKNOWLEDGE_CONCLUDE_SUCCESS, updatedState);
+  //     expect((updatedState.messageOutbox!).type).toEqual(outgoing.SEND_MESSAGE);
+  //   });
+
+  // });
+
+  // describe('start in WaitForOpponentConclude', () => {
+  //   describe('action taken: messageReceived', () => {
+  //     const state = states.waitForOpponentConclude({
+  //       ...defaultsA,
+  //       penultimatePosition: { data: aResignsAfterOneRound.restingHex, signature: 'sig' },
+  //       lastPosition: { data: aResignsAfterOneRound.concludeHex, signature: 'sig' },
+  //       turnNum: 8,
+  //     });
+
+  // const action = actions.messageReceived(aResignsAfterOneRound.conclude2Hex, aResignsAfterOneRound.conclude2Sig);
+  // const updatedState = walletReducer(state, action);
+  // itTransitionsToStateType(states.ACKNOWLEDGE_CONCLUDE_SUCCESS, updatedState);
+  //   });
+  // });
+
+  // describe('start in AcknowledgConcludeSuccess', () => {
+  //   describe('action taken: conclude success acknowledged', () => {
+  //     const state = states.acknowledgeConcludeSuccess({
+  //       ...defaultsA,
+  //       penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: 'sig' },
+  //       lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: 'sig' },
+  //       turnNum: 9,
+  //     });
+
+  //     const action = actions.concludeSuccessAcknowledged();
+  //     const updatedState = walletReducer(state, action);
+  //     itTransitionsToStateType(states.APPROVE_WITHDRAWAL, updatedState);
+  //     expect((updatedState.messageOutbox!).type).toEqual(outgoing.CONCLUDE_SUCCESS);
+  //   });
+
+  //   describe('action taken: conclude success acknowledged, adjudicator does not exist', () => {
+  //     const state = states.acknowledgeConcludeSuccess({
+  //       ...defaultsA,
+  //       penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: 'sig' },
+  //       lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: 'sig' },
+  //       turnNum: 9,
+  //       adjudicator: undefined,
+  //     });
+
+  //     const action = actions.concludeSuccessAcknowledged();
+  //     const updatedState = walletReducer(state, action);
+  //     itTransitionsToStateType(states.ACKNOWLEDGE_CLOSE_SUCCESS, updatedState);
+  //     expect((updatedState.messageOutbox!).type).toEqual(outgoing.CONCLUDE_SUCCESS);
+  //   });
+
+  // });
+
+  describe('start in AcknowledgCloseSuccess', () => {
+    describe('action taken: close success acknowledged', () => {
+      const state = states.acknowledgeCloseSuccess({
+        ...defaultsA,
+        penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: 'sig' },
+        lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: 'sig' },
+        turnNum: 9,
+      });
+
+      const action = actions.closeSuccessAcknowledged();
+      const updatedState = walletReducer(state, action);
+      itTransitionsToStateType(states.WAIT_FOR_CHANNEL, updatedState);
+      expect((updatedState.messageOutbox!).type).toEqual(outgoing.CLOSE_SUCCESS);
     });
-
-    const action = actions.concludeApproved();
-    const updatedState = walletReducer(state, action);
-    itTransitionsToStateType(states.ACKNOWLEDGE_CONCLUDE_SUCCESS, updatedState);
-    expect((updatedState.messageOutbox!).type).toEqual(outgoing.SEND_MESSAGE);
   });
-
-});
-
-describe('start in WaitForOpponentConclude', () => {
-  describe('action taken: messageReceived', () => {
-    const state = states.waitForOpponentConclude({
-      ...defaultsA,
-      penultimatePosition: { data: aResignsAfterOneRound.restingHex, signature: 'sig' },
-      lastPosition: { data: aResignsAfterOneRound.concludeHex, signature: 'sig' },
-      turnNum: 8,
-    });
-
-    const action = actions.messageReceived(aResignsAfterOneRound.conclude2Hex, aResignsAfterOneRound.conclude2Sig);
-    const updatedState = walletReducer(state, action);
-    itTransitionsToStateType(states.ACKNOWLEDGE_CONCLUDE_SUCCESS, updatedState);
-  });
-});
-
-describe('start in AcknowledgConcludeSuccess', () => {
-  describe('action taken: conclude success acknowledged', () => {
-    const state = states.acknowledgeConcludeSuccess({
-      ...defaultsA,
-      penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: 'sig' },
-      lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: 'sig' },
-      turnNum: 9,
-    });
-
-    const action = actions.concludeSuccessAcknowledged();
-    const updatedState = walletReducer(state, action);
-    itTransitionsToStateType(states.APPROVE_WITHDRAWAL, updatedState);
-    expect((updatedState.messageOutbox!).type).toEqual(outgoing.CONCLUDE_SUCCESS);
-  });
-
-  describe('action taken: conclude success acknowledged, adjudicator does not exist', () => {
-    const state = states.acknowledgeConcludeSuccess({
-      ...defaultsA,
-      penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: 'sig' },
-      lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: 'sig' },
-      turnNum: 9,
-      adjudicator: undefined,
-    });
-
-    const action = actions.concludeSuccessAcknowledged();
-    const updatedState = walletReducer(state, action);
-    itTransitionsToStateType(states.ACKNOWLEDGE_CLOSE_SUCCESS, updatedState);
-    expect((updatedState.messageOutbox!).type).toEqual(outgoing.CONCLUDE_SUCCESS);
-  });
-
-});
-
-describe('start in AcknowledgCloseSuccess', () => {
-  describe('action taken: close success acknowledged', () => {
-    const state = states.acknowledgeCloseSuccess({
-      ...defaultsA,
-      penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: 'sig' },
-      lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: 'sig' },
-      turnNum: 9,
-    });
-
-    const action = actions.closeSuccessAcknowledged();
-    const updatedState = walletReducer(state, action);
-    itTransitionsToStateType(states.WAIT_FOR_CHANNEL, updatedState);
-    expect((updatedState.messageOutbox!).type).toEqual(outgoing.CLOSE_SUCCESS);
-  });
-});

--- a/src/wallet/redux/reducers/closing.ts
+++ b/src/wallet/redux/reducers/closing.ts
@@ -36,7 +36,7 @@ export const closingReducer = (state: ClosingState, action: WalletAction): Walle
 const waitForCloseConfirmedReducer = (state: states.WaitForCloseConfirmed, action: actions.WalletAction) => {
   switch (action.type) {
     case actions.TRANSACTION_CONFIRMED:
-      return states.approveWithdrawal(state);
+      return states.approveWithdrawal({ ...state });
   }
   return state;
 };

--- a/src/wallet/redux/reducers/closing.ts
+++ b/src/wallet/redux/reducers/closing.ts
@@ -37,6 +37,8 @@ const waitForCloseConfirmedReducer = (state: states.WaitForCloseConfirmed, actio
   switch (action.type) {
     case actions.TRANSACTION_CONFIRMED:
       return states.approveWithdrawal({ ...state });
+    case actions.GAME_CONCLUDED_EVENT:
+      return states.approveWithdrawal(state);
   }
   return state;
 };
@@ -45,6 +47,8 @@ const waitForCloseInitiatorReducer = (state: states.WaitForCloseInitiation, acti
   switch (action.type) {
     case actions.TRANSACTION_SENT_TO_METAMASK:
       return states.waitForCloseSubmission(state);
+    case actions.GAME_CONCLUDED_EVENT:
+      return states.approveWithdrawal(state);
   }
   return state;
 };
@@ -53,6 +57,8 @@ const waitForCloseSubmissionReducer = (state: states.WaitForCloseSubmission, act
   switch (action.type) {
     case actions.TRANSACTION_SUBMITTED:
       return states.waitForCloseConfirmed(state);
+    case actions.GAME_CONCLUDED_EVENT:
+      return states.approveWithdrawal(state);
   }
   return state;
 };

--- a/src/wallet/redux/reducers/closing.ts
+++ b/src/wallet/redux/reducers/closing.ts
@@ -8,27 +8,71 @@ import { State, Channel } from 'fmg-core';
 import decode from '../../domain/decode';
 import { signPositionHex, validSignature } from '../../utils/signing-utils';
 import { sendMessage, closeSuccess, concludeSuccess } from '../../interface/outgoing';
-import { handleSignatureAndValidationMessages } from '../../utils/state-utils';
+import { Signature } from '../../domain';
+import { createConcludeTransaction } from '../../utils/transaction-generator';
 
 export const closingReducer = (state: ClosingState, action: WalletAction): WalletState => {
-  // Handle any signature/validation request centrally to avoid duplicating code for each state
-  if (action.type === actions.OWN_POSITION_RECEIVED || action.type === actions.OPPONENT_POSITION_RECEIVED) {
-    return { ...state, messageOutbox: handleSignatureAndValidationMessages(state, action) };
-  }
   switch (state.type) {
     case states.APPROVE_CONCLUDE:
       return approveConcludeReducer(state, action);
     case states.WAIT_FOR_OPPONENT_CONCLUDE:
       return waitForOpponentConclude(state, action);
-    case states.ACKNOWLEDGE_CONCLUDE_SUCCESS:
-      return acknowledgeConcludeSuccessReducer(state, action);
+    case states.APPROVE_CLOSE_ON_CHAIN:
+      return approveCloseOnChainReducer(state, action);
     case states.ACKNOWLEDGE_CLOSE_SUCCESS:
       return acknowledgeCloseSuccessReducer(state, action);
     case states.ACKNOWLEDGE_CLOSED_ON_CHAIN:
       return acknowledgeClosedOnChainReducer(state, action);
+    case states.WAIT_FOR_CLOSE_INITIATION:
+      return waitForCloseInitiatorReducer(state, action);
+    case states.WAIT_FOR_CLOSE_SUBMISSION:
+      return waitForCloseSubmissionReducer(state, action);
+    case states.WAIT_FOR_CLOSE_CONFIRMED:
+      return waitForCloseConfirmedReducer(state, action);
     default:
       return unreachable(state);
   }
+};
+const waitForCloseConfirmedReducer = (state: states.WaitForCloseConfirmed, action: actions.WalletAction) => {
+  switch (action.type) {
+    case actions.TRANSACTION_CONFIRMED:
+      return states.approveWithdrawal(state);
+  }
+  return state;
+};
+
+const waitForCloseInitiatorReducer = (state: states.WaitForCloseInitiation, action: actions.WalletAction) => {
+  switch (action.type) {
+    case actions.TRANSACTION_SENT_TO_METAMASK:
+      return states.waitForCloseSubmission(state);
+  }
+  return state;
+};
+
+const waitForCloseSubmissionReducer = (state: states.WaitForCloseSubmission, action: actions.WalletAction) => {
+  switch (action.type) {
+    case actions.TRANSACTION_SUBMITTED:
+      return states.waitForCloseConfirmed(state);
+  }
+  return state;
+};
+
+const approveCloseOnChainReducer = (state: states.ApproveCloseOnChain, action: actions.WalletAction) => {
+  switch (action.type) {
+    case actions.APPROVE_CLOSE:
+
+      const { penultimatePosition: from, lastPosition: to } = state;
+      const transactionOutbox = createConcludeTransaction(
+        state.adjudicator,
+        from.data,
+        to.data,
+        new Signature(from.signature),
+        new Signature(to.signature));
+      return states.waitForCloseInitiation({ ...state, transactionOutbox });
+    case actions.GAME_CONCLUDED_EVENT:
+      return states.approveWithdrawal(state);
+  }
+  return state;
 };
 
 const approveConcludeReducer = (state: states.ApproveConclude, action: WalletAction) => {
@@ -39,7 +83,7 @@ const approveConcludeReducer = (state: states.ApproveConclude, action: WalletAct
       const { positionData, positionSignature, sendMessageAction } = composeConcludePosition(state);
       const lastState = decode(state.lastPosition.data);
       if (lastState.stateType === State.StateType.Conclude) {
-        return states.acknowledgeConcludeSuccess({
+        return states.approveCloseOnChain({
           ...state,
           turnNum: decode(positionData).turnNum,
           penultimatePosition: state.lastPosition,
@@ -71,36 +115,19 @@ const waitForOpponentConclude = (state: states.WaitForOpponentConclude, action: 
       if (!validSignature(action.data, action.signature, opponentAddress)) { return state; }
       // check transition
       if (!validTransition(state, concludePosition)) { return state; }
-      return states.acknowledgeConcludeSuccess({
+      return states.approveCloseOnChain({
         ...state,
         turnNum: concludePosition.turnNum,
         penultimatePosition: state.lastPosition,
         lastPosition: { data: action.data, signature: action.signature },
+        messageOutbox: concludeSuccess(),
       });
     default:
       return state;
   }
 };
 
-const acknowledgeConcludeSuccessReducer = (state: states.AcknowledgeConcludeSuccess, action: WalletAction) => {
-  switch (action.type) {
-    case actions.CONCLUDE_SUCCESS_ACKNOWLEDGED:
-      if (state.adjudicator) {
-        return states.approveWithdrawal({
-          ...state,
-          adjudicator: state.adjudicator,
-          messageOutbox: concludeSuccess(),
-        });
-      } else {
-        return states.acknowledgeCloseSuccess({
-          ...state,
-          messageOutbox: concludeSuccess(),
-        });
-      }
-    default:
-      return state;
-  }
-};
+
 
 const acknowledgeCloseSuccessReducer = (state: states.AcknowledgeCloseSuccess, action: WalletAction) => {
   switch (action.type) {

--- a/src/wallet/redux/reducers/index.ts
+++ b/src/wallet/redux/reducers/index.ts
@@ -11,7 +11,7 @@ import {
   waitForLogin,
   approveConclude,
   ApproveConclude,
-  acknowlegeClosedOnChain,
+  acknowledgeClosedOnChain,
   AcknowledgeClosedOnChain,
 } from '../../states';
 
@@ -64,13 +64,15 @@ export const walletReducer = (state: WalletState = initialState, action: WalletA
 };
 
 const receivedValidOwnConclusionRequest = (state: WalletState, action: WalletAction): ApproveConclude | null => {
-  if (state.stage !== FUNDING && state.stage !== RUNNING) { return null; }
+  // TODO: Handle conclude if the game isn't funded.
+  if (state.stage !== RUNNING) { return null; }
   if (action.type !== CONCLUDE_REQUESTED || !ourTurn(state)) { return null; }
   return approveConclude(state);
 };
 
 const receivedValidOpponentConclusionRequest = (state: WalletState, action: WalletAction): ApproveConclude | null => {
-  if (state.stage !== FUNDING && state.stage !== RUNNING) { return null; }
+  // TODO: Handle conclude if the game isn't funded.
+  if (state.stage !== RUNNING) { return null; }
   if (action.type !== MESSAGE_RECEIVED) { return null; }
 
   let position;
@@ -102,7 +104,7 @@ const receivedValidOpponentClosedOnChain = (state: WalletState, action: WalletAc
   if (action.type !== GAME_CONCLUDED_EVENT) { return null; }
 
   if ('adjudicator' in state && state.adjudicator) {
-    return acknowlegeClosedOnChain({ ...state, adjudicator: state.adjudicator });
+    return acknowledgeClosedOnChain({ ...state, adjudicator: state.adjudicator });
   }
   return null;
 };

--- a/src/wallet/redux/reducers/index.ts
+++ b/src/wallet/redux/reducers/index.ts
@@ -11,8 +11,6 @@ import {
   waitForLogin,
   approveConclude,
   ApproveConclude,
-  acknowledgeClosedOnChain,
-  AcknowledgeClosedOnChain,
 } from '../../states';
 
 import { initializingReducer } from './initializing';
@@ -23,7 +21,7 @@ import { challengingReducer } from './challenging';
 import { respondingReducer } from './responding';
 import { withdrawingReducer } from './withdrawing';
 import { closingReducer } from './closing';
-import { WalletAction, CONCLUDE_REQUESTED, MESSAGE_RECEIVED, GAME_CONCLUDED_EVENT } from '../actions';
+import { WalletAction, CONCLUDE_REQUESTED, MESSAGE_RECEIVED, } from '../actions';
 import { unreachable, ourTurn, validTransition } from '../../utils/reducer-utils';
 import decode from '../../domain/decode';
 import { validSignature } from '../../utils/signing-utils';
@@ -37,9 +35,6 @@ export const walletReducer = (state: WalletState = initialState, action: WalletA
 
   const conclusionStateFromOpponentRequest = receivedValidOpponentConclusionRequest(state, action);
   if (conclusionStateFromOpponentRequest) { return conclusionStateFromOpponentRequest; }
-
-  const closedOnChainState = receivedValidOpponentClosedOnChain(state, action);
-  if (closedOnChainState) { return closedOnChainState; }
 
   switch (state.stage) {
     case INITIALIZING:
@@ -99,12 +94,3 @@ const receivedValidOpponentConclusionRequest = (state: WalletState, action: Wall
   });
 };
 
-const receivedValidOpponentClosedOnChain = (state: WalletState, action: WalletAction): AcknowledgeClosedOnChain | null => {
-  if (state.stage !== FUNDING && state.stage !== RUNNING && state.stage !== CLOSING) { return null; }
-  if (action.type !== GAME_CONCLUDED_EVENT) { return null; }
-
-  if ('adjudicator' in state && state.adjudicator) {
-    return acknowledgeClosedOnChain({ ...state, adjudicator: state.adjudicator });
-  }
-  return null;
-};

--- a/src/wallet/redux/reducers/index.ts
+++ b/src/wallet/redux/reducers/index.ts
@@ -59,15 +59,13 @@ export const walletReducer = (state: WalletState = initialState, action: WalletA
 };
 
 const receivedValidOwnConclusionRequest = (state: WalletState, action: WalletAction): ApproveConclude | null => {
-  // TODO: Handle conclude if the game isn't funded.
-  if (state.stage !== RUNNING) { return null; }
+  if (state.stage !== FUNDING && state.stage !== RUNNING) { return null; }
   if (action.type !== CONCLUDE_REQUESTED || !ourTurn(state)) { return null; }
   return approveConclude(state);
 };
 
 const receivedValidOpponentConclusionRequest = (state: WalletState, action: WalletAction): ApproveConclude | null => {
-  // TODO: Handle conclude if the game isn't funded.
-  if (state.stage !== RUNNING) { return null; }
+  if (state.stage !== FUNDING && state.stage !== RUNNING) { return null; }
   if (action.type !== MESSAGE_RECEIVED) { return null; }
 
   let position;

--- a/src/wallet/redux/reducers/withdrawing.ts
+++ b/src/wallet/redux/reducers/withdrawing.ts
@@ -2,6 +2,9 @@ import * as states from '../../states';
 import * as actions from '../actions';
 import { unreachable } from '../../utils/reducer-utils';
 import { handleSignatureAndValidationMessages } from '../../utils/state-utils';
+import { createWithdrawTransaction } from '../../utils/transaction-generator';
+import { signVerificationData } from '../../utils/signing-utils';
+import { Signature } from '../../domain';
 
 export const withdrawingReducer = (state: states.WithdrawingState, action: actions.WalletAction): states.WalletState => {
   // Handle any signature/validation request centrally to avoid duplicating code for each state
@@ -25,9 +28,10 @@ export const withdrawingReducer = (state: states.WithdrawingState, action: actio
 const approveWithdrawalReducer = (state: states.ApproveWithdrawal, action: actions.WalletAction): states.WalletState => {
   switch (action.type) {
     case actions.WITHDRAWAL_APPROVED:
-      // todo: construct withdrawal
-
-      return states.waitForWithdrawalInitiation(state);
+      const myAddress = state.participants[state.ourIndex];
+      const signature = new Signature(signVerificationData(myAddress, myAddress, state.channelId, state.privateKey));
+      const transactionOutbox = createWithdrawTransaction(state.adjudicator, myAddress, myAddress, state.channelId, signature);
+      return states.waitForWithdrawalInitiation({ ...state, transactionOutbox });
     case actions.WITHDRAWAL_REJECTED:
       return states.acknowledgeCloseSuccess(state);
     default:

--- a/src/wallet/redux/reducers/withdrawing.ts
+++ b/src/wallet/redux/reducers/withdrawing.ts
@@ -20,6 +20,7 @@ export const withdrawingReducer = (state: states.WithdrawingState, action: actio
       return waitForWithdrawalConfirmationReducer(state, action);
     case states.ACKNOWLEDGE_WITHDRAWAL_SUCCESS:
       return acknowledgeWithdrawalSuccessReducer(state, action);
+
     default:
       return unreachable(state);
   }

--- a/src/wallet/redux/reducers/withdrawing.ts
+++ b/src/wallet/redux/reducers/withdrawing.ts
@@ -5,6 +5,7 @@ import { handleSignatureAndValidationMessages } from '../../utils/state-utils';
 import { createWithdrawTransaction } from '../../utils/transaction-generator';
 import { signVerificationData } from '../../utils/signing-utils';
 import { Signature } from '../../domain';
+import { closeSuccess } from '../../interface/outgoing';
 
 export const withdrawingReducer = (state: states.WithdrawingState, action: actions.WalletAction): states.WalletState => {
   // Handle any signature/validation request centrally to avoid duplicating code for each state
@@ -61,7 +62,8 @@ const waitForWithdrawalConfirmationReducer = (state: states.WaitForWithdrawalCon
 const acknowledgeWithdrawalSuccessReducer = (state: states.AcknowledgeWithdrawalSuccess, action: actions.WalletAction): states.WalletState => {
   switch (action.type) {
     case actions.WITHDRAWAL_SUCCESS_ACKNOWLEDGED:
-      return states.waitForChannel(state);
+      // TODO: We shouldn't be sending out a close success in the withdrawal reducer
+      return states.waitForChannel({ ...state, messageOutbox: closeSuccess() });
     default:
       return state;
   }

--- a/src/wallet/states/closing.ts
+++ b/src/wallet/states/closing.ts
@@ -1,4 +1,4 @@
-import { AdjudicatorExists, adjudicatorExists, ChannelOpen, channelOpen, AdjudicatorMightExist, adjudicatorMightExist, } from './shared';
+import { AdjudicatorExists, adjudicatorExists, ChannelOpen, channelOpen, } from './shared';
 
 // stage
 export const CLOSING = 'CLOSING';
@@ -6,23 +6,28 @@ export const CLOSING = 'CLOSING';
 // state types
 export const APPROVE_CONCLUDE = 'APPROVE_CONCLUDE';
 export const WAIT_FOR_OPPONENT_CONCLUDE = 'WAIT_FOR_OPPONENT_CONCLUDE';
-export const ACKNOWLEDGE_CONCLUDE_SUCCESS = 'ACKNOWLEDGE_CONCLUDE_SUCCESS';
 export const ACKNOWLEDGE_CLOSE_SUCCESS = 'ACKNOWLEDGE_CLOSE_SUCCESS';
 export const ACKNOWLEDGE_CLOSED_ON_CHAIN = 'ACKNOWLEDGE_CLOSED_ON_CHAIN';
+export const APPROVE_CLOSE_ON_CHAIN = 'APPROVE_CLOSE_ON_CHAIN';
+export const WAIT_FOR_CLOSE_INITIATION = 'WAIT_FOR_CLOSE_INITIATION';
+export const WAIT_FOR_CLOSE_SUBMISSION = 'WAIT_FOR_CLOSE_SUBMISSION';
+export const WAIT_FOR_CLOSE_CONFIRMED = 'WAIT_FOR_CLOSE_CONFIRMED';
 
-export interface ApproveConclude extends AdjudicatorMightExist {
+export interface WaitForCloseConfirmed extends AdjudicatorExists {
+  type: typeof WAIT_FOR_CLOSE_CONFIRMED;
+  stage: typeof CLOSING;
+}
+
+export interface ApproveConclude extends AdjudicatorExists {
   type: typeof APPROVE_CONCLUDE;
   stage: typeof CLOSING;
 }
 
-export interface WaitForOpponentConclude extends AdjudicatorMightExist {
+export interface WaitForOpponentConclude extends AdjudicatorExists {
   type: typeof WAIT_FOR_OPPONENT_CONCLUDE;
   stage: typeof CLOSING;
 }
-export interface AcknowledgeConcludeSuccess extends AdjudicatorMightExist {
-  type: typeof ACKNOWLEDGE_CONCLUDE_SUCCESS;
-  stage: typeof CLOSING;
-}
+
 
 export interface AcknowledgeCloseSuccess extends ChannelOpen {
   type: typeof ACKNOWLEDGE_CLOSE_SUCCESS;
@@ -33,31 +38,59 @@ export interface AcknowledgeClosedOnChain extends AdjudicatorExists {
   type: typeof ACKNOWLEDGE_CLOSED_ON_CHAIN;
   stage: typeof CLOSING;
 }
-
-export function approveConclude<T extends AdjudicatorMightExist>(params: T): ApproveConclude {
-  return { type: APPROVE_CONCLUDE, stage: CLOSING, ...adjudicatorMightExist(params) };
+export interface ApproveCloseOnChain extends AdjudicatorExists {
+  type: typeof APPROVE_CLOSE_ON_CHAIN;
+  stage: typeof CLOSING;
 }
 
-export function waitForOpponentConclude<T extends AdjudicatorMightExist>(params: T): WaitForOpponentConclude {
-  return { type: WAIT_FOR_OPPONENT_CONCLUDE, stage: CLOSING, ...adjudicatorMightExist(params) };
+export interface WaitForCloseInitiation extends AdjudicatorExists {
+  type: typeof WAIT_FOR_CLOSE_INITIATION;
+  stage: typeof CLOSING;
 }
 
-export function acknowledgeConcludeSuccess<T extends AdjudicatorMightExist>(params: T): AcknowledgeConcludeSuccess {
-  return { type: ACKNOWLEDGE_CONCLUDE_SUCCESS, stage: CLOSING, ...adjudicatorMightExist(params) };
+export interface WaitForCloseSubmission extends AdjudicatorExists {
+  type: typeof WAIT_FOR_CLOSE_SUBMISSION;
+  stage: typeof CLOSING;
+}
+export function approveConclude<T extends AdjudicatorExists>(params: T): ApproveConclude {
+  return { type: APPROVE_CONCLUDE, stage: CLOSING, ...adjudicatorExists(params) };
+}
+export function approveCloseOnChain<T extends AdjudicatorExists>(params: T): ApproveCloseOnChain {
+  return { type: APPROVE_CLOSE_ON_CHAIN, stage: CLOSING, ...adjudicatorExists(params) };
+}
+
+export function waitForOpponentConclude<T extends AdjudicatorExists>(params: T): WaitForOpponentConclude {
+  return { type: WAIT_FOR_OPPONENT_CONCLUDE, stage: CLOSING, ...adjudicatorExists(params) };
 }
 
 export function acknowledgeCloseSuccess<T extends ChannelOpen>(params: T): AcknowledgeCloseSuccess {
   return { type: ACKNOWLEDGE_CLOSE_SUCCESS, stage: CLOSING, ...channelOpen(params) };
 }
 
-export function acknowlegeClosedOnChain<T extends AdjudicatorExists>(params: T): AcknowledgeClosedOnChain {
+export function acknowledgeClosedOnChain<T extends AdjudicatorExists>(params: T): AcknowledgeClosedOnChain {
   return { type: ACKNOWLEDGE_CLOSED_ON_CHAIN, stage: CLOSING, ...adjudicatorExists(params) };
 }
+
+export function waitForCloseInitiation<T extends AdjudicatorExists>(params: T): WaitForCloseInitiation {
+  return { type: WAIT_FOR_CLOSE_INITIATION, stage: CLOSING, ...adjudicatorExists(params) };
+}
+
+export function waitForCloseSubmission<T extends AdjudicatorExists>(params: T): WaitForCloseSubmission {
+  return { type: WAIT_FOR_CLOSE_SUBMISSION, stage: CLOSING, ...adjudicatorExists(params) };
+}
+
+export function waitForCloseConfirmed<T extends AdjudicatorExists>(params: T): WaitForCloseConfirmed {
+  return { type: WAIT_FOR_CLOSE_CONFIRMED, stage: CLOSING, ...adjudicatorExists(params) };
+}
+
 
 export type ClosingState = (
   | ApproveConclude
   | WaitForOpponentConclude
-  | AcknowledgeConcludeSuccess
   | AcknowledgeClosedOnChain
   | AcknowledgeCloseSuccess
+  | ApproveCloseOnChain
+  | WaitForCloseInitiation
+  | WaitForCloseSubmission
+  | WaitForCloseConfirmed
 );

--- a/src/wallet/states/closing.ts
+++ b/src/wallet/states/closing.ts
@@ -1,4 +1,4 @@
-import { AdjudicatorExists, adjudicatorExists, ChannelOpen, channelOpen, } from './shared';
+import { AdjudicatorExists, adjudicatorExists, ChannelOpen, channelOpen, AdjudicatorMightExist, adjudicatorMightExist, } from './shared';
 
 // stage
 export const CLOSING = 'CLOSING';
@@ -18,12 +18,17 @@ export interface WaitForCloseConfirmed extends AdjudicatorExists {
   stage: typeof CLOSING;
 }
 
-export interface ApproveConclude extends AdjudicatorExists {
+export interface ApproveConclude extends AdjudicatorMightExist {
   type: typeof APPROVE_CONCLUDE;
   stage: typeof CLOSING;
 }
 
-export interface WaitForOpponentConclude extends AdjudicatorExists {
+export interface WaitForOpponentConclude extends AdjudicatorMightExist {
+  type: typeof WAIT_FOR_OPPONENT_CONCLUDE;
+  stage: typeof CLOSING;
+}
+
+export interface AcknowledgeConcludeSuccess extends AdjudicatorMightExist {
   type: typeof WAIT_FOR_OPPONENT_CONCLUDE;
   stage: typeof CLOSING;
 }
@@ -52,15 +57,15 @@ export interface WaitForCloseSubmission extends AdjudicatorExists {
   type: typeof WAIT_FOR_CLOSE_SUBMISSION;
   stage: typeof CLOSING;
 }
-export function approveConclude<T extends AdjudicatorExists>(params: T): ApproveConclude {
-  return { type: APPROVE_CONCLUDE, stage: CLOSING, ...adjudicatorExists(params) };
+export function approveConclude<T extends AdjudicatorMightExist>(params: T): ApproveConclude {
+  return { type: APPROVE_CONCLUDE, stage: CLOSING, ...adjudicatorMightExist(params) };
 }
 export function approveCloseOnChain<T extends AdjudicatorExists>(params: T): ApproveCloseOnChain {
   return { type: APPROVE_CLOSE_ON_CHAIN, stage: CLOSING, ...adjudicatorExists(params) };
 }
 
-export function waitForOpponentConclude<T extends AdjudicatorExists>(params: T): WaitForOpponentConclude {
-  return { type: WAIT_FOR_OPPONENT_CONCLUDE, stage: CLOSING, ...adjudicatorExists(params) };
+export function waitForOpponentConclude<T extends AdjudicatorMightExist>(params: T): WaitForOpponentConclude {
+  return { type: WAIT_FOR_OPPONENT_CONCLUDE, stage: CLOSING, ...adjudicatorMightExist(params) };
 }
 
 export function acknowledgeCloseSuccess<T extends ChannelOpen>(params: T): AcknowledgeCloseSuccess {

--- a/src/wallet/states/withdrawing.ts
+++ b/src/wallet/states/withdrawing.ts
@@ -1,4 +1,4 @@
-import { AdjudicatorExists, adjudicatorExists } from './shared'; 
+import { AdjudicatorExists, adjudicatorExists } from './shared';
 
 // stage
 export const WITHDRAWING = 'STAGE.WITHDRAWING';
@@ -13,6 +13,8 @@ export interface ApproveWithdrawal extends AdjudicatorExists {
   type: typeof APPROVE_WITHDRAWAL;
   stage: typeof WITHDRAWING;
 }
+
+
 
 export interface WaitForWithdrawalInitiation extends AdjudicatorExists {
   type: typeof WAIT_FOR_WITHDRAWAL_INITIATION;
@@ -44,6 +46,7 @@ export function waitForWithdrawalConfirmation<T extends AdjudicatorExists>(param
 export function acknowledgeWithdrawalSuccess<T extends AdjudicatorExists>(params: T): AcknowledgeWithdrawalSuccess {
   return { ...adjudicatorExists(params), type: ACKNOWLEDGE_WITHDRAWAL_SUCCESS, stage: WITHDRAWING };
 }
+
 
 export type WithdrawingState = (
   | ApproveWithdrawal


### PR DESCRIPTION
TODO:

- [x] Fix tests
- [x] Handle GAME_CONCLUDED event during transaction submission
- [x] Handle transaction error when concluding a game (handling GAME_CONCLUDED event handles this, we don't need to worry about the transacton failed)
- [x] Handle conclusions without adjudicator
- [ ] ~~Use `concludeAndWithdraw` instead of calling `conclude` then `withdraw`~~ (Will implement later)