### PR TITLE
Handle funding actions that may come in during transaction deploy

### DIFF
--- a/src/wallet/redux/reducers/funding.ts
+++ b/src/wallet/redux/reducers/funding.ts
@@ -302,7 +302,7 @@ const validTransitionToPostFundState = (state: states.FundingState, data: string
   return true;
 };
 
-const composePostFundState = (state: states.AWaitForDeposit | states.WaitForDepositConfirmation | states.BWaitForPostFundSetup) => {
+const composePostFundState = (state: states.AWaitForDeposit | states.BWaitForPostFundSetup) => {
   const lastState = decode(state.lastPosition.data);
   const { libraryAddress, channelNonce, participants, turnNum } = state;
   const channel = new Channel(libraryAddress, channelNonce, participants);

--- a/src/wallet/states/shared.ts
+++ b/src/wallet/states/shared.ts
@@ -1,5 +1,6 @@
 import { TransactionRequest } from "ethers/providers";
 import { ResponseAction } from "../interface/outgoing";
+import { Action } from 'redux';
 
 export interface Base {
   messageOutbox?: ResponseAction;
@@ -33,7 +34,7 @@ export interface ChannelPartiallyOpen extends AddressExists {
 
 export interface ChannelOpen extends ChannelPartiallyOpen {
   penultimatePosition: SignedPosition;
-  unvalidatedNewPosition?: SignedPosition;
+  unhandledAction?: Action;
 }
 
 export interface AdjudicatorMightExist extends ChannelOpen {
@@ -69,8 +70,8 @@ export function channelPartiallyOpen<T extends ChannelPartiallyOpen>(params: T):
 }
 
 export function channelOpen<T extends ChannelOpen>(params: T): ChannelOpen {
-  const { penultimatePosition, unvalidatedNewPosition } = params;
-  return { ...channelPartiallyOpen(params), penultimatePosition, unvalidatedNewPosition };
+  const { penultimatePosition, unhandledAction } = params;
+  return { ...channelPartiallyOpen(params), penultimatePosition, unhandledAction };
 }
 
 export function adjudicatorMightExist<T extends AdjudicatorMightExist>(params: T): AdjudicatorMightExist {

--- a/src/wallet/utils/contract-utils.ts
+++ b/src/wallet/utils/contract-utils.ts
@@ -8,7 +8,6 @@ export async function getProvider(): Promise<ethers.providers.Web3Provider> {
 }
 
 export async function getAdjudicatorContract(contractAddress: string, provider) {
-  console.log(contractAddress);
   return new ethers.Contract(contractAddress, getSimpleAdjudicatorInterface(), provider);
 }
 


### PR DESCRIPTION
Addresses #365 

The issue was caused by the `FUNDING_RECEIVED_EVENT` action being dispatched when the reducer was in a waiting for transaction state. 

I've taken the unvalidated position logic and generalized it to store an action that can be handled later.

Now when the `FUNDING_RECEIVED_EVENT` occurs when the wallet is in a waiting for transaction state it will store the action and it will be handled once the transaction is confirmed.