### PR TITLE
Fix runtime error when running yarn start against dev network

### DIFF
--- a/src/redux/login/saga.ts
+++ b/src/redux/login/saga.ts
@@ -5,7 +5,7 @@ import { reduxSagaFirebase } from '../../gateways/firebase';
 import { walletSaga } from '../../wallet';
 import metamaskSaga from '../metamask/saga';
 
-import RPSGameArtifact from '../../../contracts/artifacts/RockPaperScissorsGame.json';
+import RPSGameArtifact from '../../../build/contracts/RockPaperScissorsGame.json';
 
 function* loginSaga() {
   try {
@@ -51,9 +51,9 @@ function* loginStatusWatcherSaga() {
 
 export default function* loginRootSaga() {
   const metaMask = yield metamaskSaga();
-  
+
   // If metamask is not properly set up we can halt processing and wait for the reload
-  if (!metaMask){
+  if (!metaMask) {
     return;
   }
 


### PR DESCRIPTION
There was reference to a JSON artifact in `contract/artifacts/` folder. This would cause a run time error when  targeting the development network as that JSON artifact doesn't contain details for the development network.

I've switched the path to `build/contracts` like other JSON artifact references. If we're targeting a network other than development the webpack will automatically switch the  `build/contract` references to the precompiled artifacts in `contract/artifacts`